### PR TITLE
Run ruby_binary with the interpreter in a SDK again

### DIFF
--- a/ruby/private/binary_wrapper.tpl
+++ b/ruby/private/binary_wrapper.tpl
@@ -1,3 +1,8 @@
+#shell #!/usr/bin/env bash
+#shell # This conditional is evaluated as true in Ruby, false in shell
+#shell if [ ]; then
+#shell eval <<'END_OF_RUBY'
+#shell # -- begin Ruby --
 #!/usr/bin/env ruby
 
 # Ruby-port of the Bazel's wrapper script for Python
@@ -124,3 +129,21 @@ end
 if __FILE__ == $0
   main(ARGV)
 end
+#shell END_OF_RUBY
+#shell __END__
+#shell # -- end Ruby --
+#shell fi
+#shell # -- begin Shell Script --
+#shell 
+#shell # --- begin runfiles.bash initialization v2 ---
+#shell # Copy-pasted from the Bazel Bash runfiles library v2.
+#shell set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+#shell source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+#shell source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+#shell source "$0.runfiles/$f" 2>/dev/null || \
+#shell source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+#shell source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+#shell { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+#shell # --- end runfiles.bash initialization v2 ---
+#shell 
+#shell exec "$(rlocation {interpreter})" ${BASH_SOURCE:-$0} "$@"


### PR DESCRIPTION
when the interpreter is not the host interpreter.

* Prepares for introducing Sorbet's ruby interpreter.
* Fixes #21.

# Questions that reviewers might have
* Why does the binary_wrapper contain both of a shell script and a Ruby script in it?
  * `ruby_binary` rule needs to emit a single file so that the rule can be a source in some other rules like `sh_binary`. It cannot emit two or more files.
* Why don't you simply write entire the wrapper code in shell script?
  1. I'd like to keep the amount of shell script as small as possible to make it easier to support Windows in future
  2. To reduce the number of subprocesses spawned at runtime
  3. I'd like to write the main part of the wrapper in Ruby for ease of implementation
* What does `if [ ]; then` mean?
  * It makes bash skip the ruby part of the file -- for bash, `[ ]` is false.
* What does `eval <<'END_OF_RUBY'` mean?
  * It prevents bash from parsing the ruby code -- for bash, the ruby code is a heredoc which is never evaluated.
* What does `__END__` mean?
  * It prevents ruby from parsing the shell script part. For ruby, the rest of the file is an opaque data.
* What is the "runfiles.bash initialization" part?
  * It was copied from https://github.com/bazelbuild/bazel/blob/master/tools/bash/runfiles/runfiles.bash.
* How can I try running this change?
  * Although this change is intended to be used by #20, you can try running this change with the host interpreter by applying this patch:
    ```patch
    diff --git a/ruby/private/BUILD.host_runtime.tpl b/ruby/private/BUILD.host_runtime.tpl
    index ebdcfe8..4b02246 100644
    --- a/ruby/private/BUILD.host_runtime.tpl
    +++ b/ruby/private/BUILD.host_runtime.tpl
    @@ -14,7 +14,7 @@ ruby_toolchain(
             "-I$(RUNFILES_DIR)/org_ruby_lang_ruby_host/bundler/lib",
         ],
         runtime = "//:runtime",
    -    is_host = True,
    +    # is_host = True,
         rules_ruby_workspace = "{rules_ruby_workspace}",
         # TODO(yugui) Extract platform info from RbConfig
         # exec_compatible_with = [],
    ```
  * All tests except for the container test should success with this patch.
