### PR TITLE
Add `files` to DefaultInfo of the ruby_library

### DIFF
--- a/ruby/private/library.bzl
+++ b/ruby/private/library.bzl
@@ -14,6 +14,7 @@ def _ruby_library_impl(ctx):
         DefaultInfo(
             default_runfiles = deps.default_files,
             data_runfiles = deps.data_files,
+            files = deps.srcs,
         ),
         RubyLibrary(
             transitive_ruby_srcs = deps.srcs,


### PR DESCRIPTION
This way we can feed it to other rules as inputs, for instance — ruby_lambda or pkg_zip.