### PR TITLE
Attemping to add PATH back so CC/GCC can be found

### DIFF
--- a/ruby/private/bundle/bundle.bzl
+++ b/ruby/private/bundle/bundle.bzl
@@ -39,6 +39,8 @@ def bundle_install_impl(ctx):
     args = [
         "env",
         "-i",  # remove all environment variables
+        "-P",
+        "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/bin",
         ctx.path(ruby),  # ruby
         "--disable-gems",  # prevent the addition of gem installation directories to the default load path
         "-I",  # Used to tell Ruby where to load the library scripts
@@ -66,6 +68,8 @@ def bundle_install_impl(ctx):
     args = [
         "env",
         "-i",  # remove all environment variables
+        "-P",
+        "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/bin",
         ctx.path(ruby),  # ruby interpreter
         "--disable-gems",  # prevent the addition of gem installation directories to the default load path
         "-I",  # -I lib (adds this folder to $LOAD_PATH where ruby searchesf for things)

--- a/ruby/private/toolchains/repository_context.bzl
+++ b/ruby/private/toolchains/repository_context.bzl
@@ -4,7 +4,13 @@
 #
 
 def _eval_ruby(ruby, script, options = None):
-    arguments = ["env", "-i", ruby.interpreter_realpath]
+    arguments = [
+        "env",
+        "-i",
+        "-P",
+        "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/bin",
+        ruby.interpreter_realpath,
+    ]
     if options:
         arguments.extend(options)
     arguments.extend(["-e", script])

--- a/ruby/private/tools/repository_context.bzl
+++ b/ruby/private/tools/repository_context.bzl
@@ -4,7 +4,13 @@
 #
 
 def _eval_ruby(ruby, script, options = None):
-    arguments = ["env", "-i", ruby.interpreter_realpath]
+    arguments = [
+        "env",
+        "-i",
+        "-P",
+        "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/bin",
+        ruby.interpreter_realpath,
+    ]
     if options:
         arguments.extend(options)
     arguments.extend(["-e", script])


### PR DESCRIPTION
NOTE: experimental.

During  bundle install, for native extensions to build, cc and gcc
must be in the path. If we at least restore the path to the basic
starndard locations, it's possible native extensions will compile.