### PR TITLE
[Fix] rubocop builds

### DIFF
--- a/examples/simple_script/BUILD
+++ b/examples/simple_script/BUILD
@@ -30,3 +30,15 @@ ruby_test(
         "@bundle//:rspec",
     ],
 )
+
+# TODO: not the best way of defining this, should make `rubocop` rule like `buildifier`
+ruby_binary(
+    name = "rubocop",
+    srcs = [
+        "@bundle//:bin/rubocop",
+    ],
+    main = "@bundle//:bin/rubocop",
+    deps = [
+        "@bundle//:rubocop",
+    ],
+)

--- a/examples/simple_script/Gemfile
+++ b/examples/simple_script/Gemfile
@@ -4,3 +4,4 @@ source 'https://rubygems.org'
 
 gem 'awesome_print'
 gem 'rspec', '~> 3.7.0'
+gem 'rubocop'

--- a/examples/simple_script/Gemfile.lock
+++ b/examples/simple_script/Gemfile.lock
@@ -1,8 +1,14 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.0)
     awesome_print (1.8.0)
     diff-lcs (1.3)
+    jaro_winkler (1.5.4)
+    parallel (1.19.1)
+    parser (2.6.5.0)
+      ast (~> 2.4.0)
+    rainbow (3.0.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -16,6 +22,15 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
+    rubocop (0.77.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.6)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    ruby-progressbar (1.10.1)
+    unicode-display_width (1.6.0)
 
 PLATFORMS
   ruby
@@ -23,6 +38,7 @@ PLATFORMS
 DEPENDENCIES
   awesome_print
   rspec (~> 3.7.0)
+  rubocop
 
 BUNDLED WITH
    1.17.3

--- a/examples/simple_script/README.md
+++ b/examples/simple_script/README.md
@@ -10,3 +10,10 @@ Update gemfile using
 ```
 bundle lock --update
 ```
+
+### Rubocop
+Run rubocop with:
+
+```
+bazel run :rubocop -- $(pwd)/* -a
+```

--- a/ruby/private/bundle/bundle.bzl
+++ b/ruby/private/bundle/bundle.bzl
@@ -1,7 +1,7 @@
 load("//ruby/private:constants.bzl", "RULES_RUBY_WORKSPACE_NAME")
 
 def install_bundler(ctx, interpreter, install_bundler, dest, version):
-    args = ["env", "-i", interpreter, install_bundler, version, dest]
+    args = [interpreter, install_bundler, version, dest]
     environment = {"RUBYOPT": "--disable-gems"}
 
     result = ctx.execute(args, environment = environment)
@@ -37,8 +37,6 @@ def bundle_install_impl(ctx):
 
     # Install the Gems into the workspace
     args = [
-        "env",
-        "-i",  # remove all environment variables
         ctx.path(ruby),  # ruby
         "--disable-gems",  # prevent the addition of gem installation directories to the default load path
         "-I",  # Used to tell Ruby where to load the library scripts
@@ -58,8 +56,6 @@ def bundle_install_impl(ctx):
 
     # Create the BUILD file to expose the gems to the WORKSPACE
     args = [
-        "env",
-        "-i",  # remove all environment variables
         ctx.path(ruby),  # ruby interpreter
         "--disable-gems",  # prevent the addition of gem installation directories to the default load path
         "-I",  # -I lib (adds this folder to $LOAD_PATH where ruby searchesf for things)

--- a/ruby/private/toolchains/repository_context.bzl
+++ b/ruby/private/toolchains/repository_context.bzl
@@ -4,7 +4,7 @@
 #
 
 def _eval_ruby(ruby, script, options = None):
-    arguments = ["env", "-i", ruby.interpreter_realpath]
+    arguments = [ruby.interpreter_realpath]
     if options:
         arguments.extend(options)
     arguments.extend(["-e", script])

--- a/ruby/private/tools/repository_context.bzl
+++ b/ruby/private/tools/repository_context.bzl
@@ -4,7 +4,7 @@
 #
 
 def _eval_ruby(ruby, script, options = None):
-    arguments = ["env", "-i", ruby.interpreter_realpath]
+    arguments = [ruby.interpreter_realpath]
     if options:
         arguments.extend(options)
     arguments.extend(["-e", script])


### PR DESCRIPTION
removing the `env -i` so we can build native gems.