### PR TITLE
Adding auto-fix buildifier and auto-fix rubocop

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,11 +2,11 @@ load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 
 buildifier(
     name = "buildifier",
-    exclude_patterns = [".git/**"],
+    exclude_patterns = ["./.git/**/*"],
 )
 
 buildifier(
     name = "buildifier-check",
-    exclude_patterns = [".git/**"],
+    exclude_patterns = ["./.git/**/*"],
     mode = "check",
 )

--- a/README.md
+++ b/README.md
@@ -436,15 +436,50 @@ To get the initial stuff setup required by this repo, please run the script:
 bin/setup
 ```
 
-Whenever you'll commit something, a pre-commit hook will run as well.
+This script does a couple of very useful things, including setting up a git commit
+hook that performs rubocop fixes and buildifier fixes of the Bazel build files.
+
+You can run partial setup comamnds like so:
+
+```bash
+❯ bin/setup -h
+
+USAGE:
+  bin/setup [ gems | git-hook | help | install | main | no-git-hook ]
+
+DESCRIPTION:
+  Runs full setup without any arguments.
+
+  Accepts one argument — one of the actions that typically run
+  as part of setup.
+
+  For instance, to perform full setup:
+
+    bin/setup
+
+  Or, to run only one of the sub-functions (actions), pass
+  it as an argument:
+
+    bin/setup help
+    bin/setup no-git-hook
+
+  etc.
+```
+
+Whenever you'll commit something, a pre-commit hook will run as well. If it
+finds anything that needs fixing, it will attempt to fix it. If the resulting
+git state is different than before the commit, the commit is aborted and the user
+should add any auto-fixed modifications to the list of staged files for commit.
 
 ### Running Tests
 
-We have a handy script you can use to run all tests:
+We have a pretty useful script you can use to run all tests in the repo that run on CI:
 
 ```bash
 bin/ci
 ```
+
+On a MacBook Pro it takes about 3 minutes to run.
 
 ## Copyright
 

--- a/bin/ci
+++ b/bin/ci
@@ -14,6 +14,12 @@ export BAZEL_BUILD_OPTS="--curses=no --verbose_failures -j 15 --show_progress_ra
 export BAZEL_TEST_OPTS="--verbose_failures --test_output=streamed --test_verbose_timeout_warnings "
 export RUBY_VERSION=$(cat .ruby-version)
 
+export BashMatic__Expr="
+  source ${SHELL_INIT}
+  [[ -f ${HOME}/.bashmatic/init.sh ]] && source ${HOME}/.bashmatic/init.sh
+  set -e
+"
+
 [[ -n ${DEBUG} ]] && set -x
 
 trap exit 1 INT
@@ -21,9 +27,7 @@ trap exit 1 INT
 # Runs Rubocop Tests
 test::rubocop() {
   /usr/bin/env bash -c " 
-    source ${SHELL_INIT}
-    [[ -f ${HOME}/.bashmatic/init.sh ]] && source  ${HOME}/.bashmatic/init.sh
-    set -e
+    ${BashMatic__Expr}
     h2 'Running target: rubocop'
     bundle install --path=${BUNDLE_PATH}
     bundle exec rubocop -E -D .rubocop.yml --force-exclusion
@@ -33,10 +37,8 @@ test::rubocop() {
 # Runs Buildifier
 test::buildifier() {
   /usr/bin/env bash -c "
-    source ${SHELL_INIT}
-    [[ -f ${HOME}/.bashmatic/init.sh ]] && source  ${HOME}/.bashmatic/init.sh
+    ${BashMatic__Expr}
     h2 'Running target: buildifier'
-    set -e
     bazel run :buildifier-check
   "
 }
@@ -44,11 +46,8 @@ test::buildifier() {
 # Builds and runs workspace inside examples/simple_script
 test::simple-script() {
   /usr/bin/env bash -c "
-    source ${SHELL_INIT}
-    [[ -f ${HOME}/.bashmatic/init.sh ]] && source  ${HOME}/.bashmatic/init.sh
+    ${BashMatic__Expr}
     h2 'Testing target: simple-script'
-    set -e
-    cd examples/simple_script
     bazel ${BAZEL_OPTS} info
     bazel ${BAZEL_OPTS} build ${BAZEL_BUILD_OPTS} -- //...
     bazel ${BAZEL_OPTS} test ${BAZEL_BUILD_OPTS} ${BAZEL_TEST_OPTS} -- //...
@@ -58,10 +57,8 @@ test::simple-script() {
 
 test::workspace() {
   /usr/bin/env bash -c "
-    source ${SHELL_INIT}
-    [[ -f ${HOME}/.bashmatic/init.sh ]] && source  ${HOME}/.bashmatic/init.sh
+    ${BashMatic__Expr}
     h2 'Testing target: workspace'
-    set -e
     bazel ${BAZEL_OPTS} build ${BAZEL_BUILD_OPTS} -- //...
     bazel ${BAZEL_OPTS} test ${BAZEL_BUILD_OPTS} ${BAZEL_TEST_OPTS} -- //...
   "
@@ -70,10 +67,8 @@ test::workspace() {
 # Private 
 test::bazel-info() {
   /usr/bin/env bash -c "
-    source ${SHELL_INIT}
-    [[ -f ${HOME}/.bashmatic/init.sh ]] && source  ${HOME}/.bashmatic/init.sh
+    ${BashMatic__Expr}
     h2 'Testing target: bazel-info'
-    set -e
     bazel ${BAZEL_OPTS} version
     bazel ${BAZEL_OPTS} info
     bazel ${BAZEL_OPTS} fetch --curses=no -- '//ruby/...'

--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -2,7 +2,8 @@
 #
 # Main dependency shell script that installs BashMatic Library in ~/.bashmatic folder.
 
-export COLUMNS=90
+export COLUMNS=75
+
 set -e
 # shellcheck disable=SC1091
 source "bin/deps"
@@ -13,10 +14,68 @@ source "bin/deps"
   setup::main gems
 }
 
-info "Running Rubocop, please wait..."
-run "rubocop -F -D || rubocop -a -D -P || true"
-run::set-next show-output-on
-run "rubocop -D -P"
+run::set-all abort-on-error
 
-success "RuboCop ran successfully."
+fix::rubocop() {
+  h2::green "Running Rubocop, please wait..."
+  run       "rubocop || rubocop -a"
+  inf       "Rubocop completed."
+  ok:
+}
 
+# runs buildifer from the PATH if it exists, otherwise bazel target
+# we want pre-commit to be as fast as possible.
+fix::buildifier() {
+  h2::green "Buildifier"
+  if [[ -n $(command -v buildifier) ]]; then
+    info "Running $(command -v buildifier).."
+    run "find . -name 'BUILD*' -o -name 'WORKSPACE' -o -name '*.bzl'  | grep -v '.git' | xargs buildifier -v"
+  else
+    info "Running ${bldylw}bazel run :buildifier..."
+    run "bazel run :buildifier"
+  fi
+}
+
+__fix::cleanup() {
+  h2::green "Cleaning up..."
+  for f in "${__git_pre}" "${__git_post}"; do
+    [[ -f ${f} ]] && run "rm -f ${f}"
+  done
+}
+
+export __git_pre="/tmp/rules-ruby-git-status-pre-commit.$$"
+export __git_post="/tmp/rules-ruby-git-status-post-commit.$$"
+
+trap __fix::cleanup EXIT
+
+fix() {
+  # number of modified files
+  local changes_before=$(git status -s | md5)
+
+  git status -s >"${__git_pre}"
+
+  fix::rubocop
+  fix::buildifier
+
+  git status -s >"${__git_post}"
+
+  local changes_after=$(git status -s | md5)
+  if [[ ${changes_before} != "${changes_after}" ]]; then
+    hl::subtle "Git status -s output changed after pre-commit hook."
+    info "Changes before pre-commit hook:"
+    hr
+    diff "${pre}" "${post}"
+    hr
+    echo
+    info "ACTION: ${bldylw}Please add any respective files to the commit and retry."
+    exit 1
+  else
+    hr
+    info "No changes detected, commit will proceed."
+    exit 0
+  fi
+}
+
+fix "$@"
+
+exit 0

--- a/bin/setup
+++ b/bin/setup
@@ -11,7 +11,11 @@ setup::gems() {
 }
 
 setup::git() {
-  [[ -L .git/hooks/pre-commit ]] || run "ln -nfs bin/pre-commit .git/hooks/pre-commit"
+  inf 'Installing git pre-commit hook'
+  set -e
+  [[ -L .git/hooks/pre-commit ]] || run "cd .git/hooks && ln -nfs ../../bin/pre-commit pre-commit"
+  set +e
+  ok:
 }
 
 setup::install() {

--- a/bin/setup
+++ b/bin/setup
@@ -1,8 +1,42 @@
 #!/usr/bin/env bash
-
+#
+#
+# 
 set -e
 # shellcheck disable=SC1091
 source "bin/deps"
+
+__setup::actions() {
+  local sep="${1:-', '}"
+  printf "${bldylw}$(lib::array::join "${sep}" $(lib::util::functions-matching setup::))"
+}
+
+setup::help() {
+  printf "
+${bldpur}USAGE:${clr}
+  bin/setup [ $(__setup::actions " | ")${clr} ]
+
+${bldpur}DESCRIPTION:${clr}
+  Runs full setup without any arguments. 
+
+  Accepts one argument — one of the actions that typically run
+  as part of setup.
+
+  For instance, to perform full setup:
+
+    ${bldylw}bin/setup${clr}
+
+  Or, to run only one of the sub-functions (actions), pass 
+  it as an argument:
+    
+    ${bldylw}bin/setup help${clr}
+    ${bldylw}bin/setup no-git-hook${clr}
+
+  etc.
+ "
+}
+
+
 
 setup::gems() {
   for gem in rubocop relaxed-rubocop rubocop-performance; do
@@ -10,12 +44,25 @@ setup::gems() {
   done
 }
 
-setup::git() {
-  inf 'Installing git pre-commit hook'
+setup::no-git-hook() {
   set -e
-  [[ -L .git/hooks/pre-commit ]] || run "cd .git/hooks && ln -nfs ../../bin/pre-commit pre-commit"
+  [[ -L .git/hooks/pre-commit ]] && {
+    info 'Removing git commit hook...'
+    run "rm -f .git/hooks/pre-commit"
+    echo
+  }
   set +e
-  ok:
+}
+
+setup::git-hook() {
+  set -e
+  if [[ ! -L .git/hooks/pre-commit ]]; then
+    info 'Installing git pre-commit hook'
+    run "cd .git/hooks && ln -nfs ../../bin/pre-commit pre-commit && cd -"
+  else
+    info: "git pre-commit hook is already installed."
+  fi
+  set +e
 }
 
 setup::install() {
@@ -36,7 +83,7 @@ setup::install() {
       /usr/bin/env bash bin/show-env || true
     fi
   else
-    error "Operating system $(uname -s) is not currently supported." >&2
+    error "Operating system ${os} is not currently supported." >&2
   fi
   echo
   return 0
@@ -44,19 +91,27 @@ setup::install() {
 
 setup::main() {
   local action="$1"
+  [[ "${action}" == "-h" || ${action} == "--help" ]] && action="help"
   local func="setup::${action}"
 
-  if lib::util::is-a-function "${func}"; then
-    h2 "Executing partial setup for action ${bldylw}${action}"
-    shift
-    ${func} "$@"
+  if [[ -n ${action} ]] ; then
+    if lib::util::is-a-function "${func}"; then
+      [[ ${action} != "help" ]] && h2 "Executing partial setup for action ${bldylw}${action}"
+      shift
+      ${func} "$@"
+    else
+      h1 "Invalid action provided." "Valid actions are: $(__setup::actions)"
+      exit 1
+    fi
   else
     set +e
     h2 "Installing required development dependencies for working with rules_ruby and Bazel."
     setup::gems
-    [[ -z ${CI} ]] && setup::git
+    [[ -z ${CI} ]] && setup::git-hook
     setup::install "$@"
   fi
 }
 
 setup::main "$@"
+
+

--- a/bin/setup-darwin
+++ b/bin/setup-darwin
@@ -25,11 +25,7 @@ __setup::brew-install-jdk() {
 }
 
 __setup::brew-deps() {
-  if ! brew list | grep -q xz; then
-    "brew install xz"
-  else
-    info: "Found brew package xz."
-  fi
+  lib::brew::install::packages 'xz' 'ydiff'
 }
 
 __setup::is-bazelisk-installed() {

--- a/ruby/private/toolchains/BUILD.runtime.tpl
+++ b/ruby/private/toolchains/BUILD.runtime.tpl
@@ -9,8 +9,8 @@ package(default_visibility = ["//visibility:public"])
 ruby_toolchain(
     name = "toolchain",
     interpreter = "//:ruby_bin",
-    runtime = "//:runtime",
     rules_ruby_workspace = "{rules_ruby_workspace}",
+    runtime = "//:runtime",
     # TODO(yugui) Extract platform info from RbConfig
     # exec_compatible_with = [],
     # target_compatible_with = [],
@@ -25,14 +25,14 @@ sh_binary(
 cc_import(
     name = "libruby",
     hdrs = glob({hdrs}),
-    static_library = {static_library},
     shared_library = {shared_library},
+    static_library = {static_library},
 )
 
 cc_library(
     name = "headers",
-    includes = {includes},
     hdrs = glob({hdrs}),
+    includes = {includes},
 )
 
 filegroup(


### PR DESCRIPTION
Installing a pre-commit git hook with `bin/setup` as a symlink to `bin/pre-commit` file. 

If, after running the formatters it's determined that some files have changed (using git status -s), it shows the diff between the two states and aborts the commit so that you have a chance to add fixed files.

It does not automatically add anything to git because it would be a very large and often invalid 

Also, adding `bin/setup help` + updating README.

* also adding `bin/setup no-git-hook`
* also adding `bin/setup help`
