### PR TITLE
A hacky way to package ruby sources with vendor/bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     environment:
       PATH: "/usr/local/bin:/usr/bin:/sbin:/opt/bin:/home/circleci/repo/bin:/bin:/sbin:/usr/sbin"
       BUNDLE_PATH: /home/circleci/.bundle_cache
-      BAZEL_OPTS: "--max_idle_secs=1 --host_jvm_args=-Xmx500m --host_jvm_args=-Xms500m"
+      BAZEL_OPTS: "--max_idle_secs=1 --host_jvm_args=-Xmx400m --host_jvm_args=-Xms400m"
       BAZEL_BUILD_OPTS: "--curses=no --verbose_failures --jobs 10"
       BAZEL_TEST_OPTS: "--verbose_failures --test_output=streamed --test_verbose_timeout_warnings "
 
@@ -47,6 +47,22 @@ jobs:
           name: "Bazel Build & Test Workspace"
           command: |
             /usr/bin/env bash bin/test-suite workspace
+
+  bazel_ruby_package_zip:
+    <<: *bazel_defaults
+    steps:
+      - checkout
+
+      - run:
+          name: "Install ~/.bazelrc and run setup"
+          command: |
+            cp .circleci/.bazelrc ${HOME}
+            /usr/bin/env bash bin/setup
+
+      - run:
+          name: "Bazel Build & Test Workspace"
+          command: |
+            cd examples/simple_lambda && bazel ${BAZEL_OPTS} build ${BAZEL_BUILD_OPTS} -- :all
 
   bazel_build_examples:
     <<: *bazel_defaults
@@ -105,6 +121,7 @@ jobs:
 workflows:
   rules_ruby:
     jobs:
+      - bazel_ruby_package_zip
       - bazel_build_workspace
       - bazel_build_examples
       - buildifier

--- a/examples/simple_lambda/BUILD.bazel
+++ b/examples/simple_lambda/BUILD.bazel
@@ -1,0 +1,16 @@
+package(default_visibility = ["//:__subpackages__"])
+
+load(
+    "@bazelruby_ruby_rules//ruby:defs.bzl",
+    "ruby_package_zip",
+)
+
+ruby_package_zip(
+    name = "ruby-lambda-package",
+    srcs = [
+        "Gemfile",
+        "Gemfile.lock",
+        "lib/lambda.rb",
+        "template.yml",
+    ],
+)

--- a/examples/simple_lambda/Gemfile
+++ b/examples/simple_lambda/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'awesome_print'
+gem 'colored2'
+gem 'oj'
+gem 'rspec'
+gem 'rubocop'

--- a/examples/simple_lambda/Gemfile.lock
+++ b/examples/simple_lambda/Gemfile.lock
@@ -1,0 +1,46 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.0)
+    awesome_print (1.8.0)
+    colored2 (3.1.2)
+    diff-lcs (1.3)
+    jaro_winkler (1.5.4)
+    oj (3.10.0)
+    parallel (1.19.1)
+    parser (2.6.5.0)
+      ast (~> 2.4.0)
+    rainbow (3.0.0)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.0)
+      rspec-support (~> 3.9.0)
+    rspec-expectations (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.0)
+    rubocop (0.78.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.6)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    ruby-progressbar (1.10.1)
+    unicode-display_width (1.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  awesome_print
+  colored2
+  oj
+  rspec
+  rubocop
+

--- a/examples/simple_lambda/README.md
+++ b/examples/simple_lambda/README.md
@@ -1,0 +1,21 @@
+# Ruby ZIP Package
+
+This rule runs `bundle install --path vendor/bundle` and creates a zip with the sources + vendor/bundle.
+
+```bazel
+
+load(
+    "@bazelruby_ruby_rules//ruby:defs.bzl",
+    "ruby_package_zip",
+)
+
+ruby_package_zip(
+    name = "ruby-lambda-package",
+    srcs = [
+        "Gemfile",
+        "Gemfile.lock",
+        "lib/lambda.rb",
+        "template.yml",
+    ],
+)
+```

--- a/examples/simple_lambda/WORKSPACE
+++ b/examples/simple_lambda/WORKSPACE
@@ -1,0 +1,34 @@
+workspace(name = "bazelruby_ruby_rules_example")
+
+# Importing rules_ruby from the parent directory for developing
+# rules_ruby itself...
+local_repository(
+    name = "bazelruby_ruby_rules",
+    path = "../..",
+)
+
+load(
+    "@bazelruby_ruby_rules//ruby:deps.bzl",
+    "ruby_register_toolchains",
+    "ruby_rules_dependencies",
+)
+
+ruby_rules_dependencies()
+
+ruby_register_toolchains(version = "2.6.5")
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+load("@bazelruby_ruby_rules//ruby:defs.bzl", "bundle_install")
+
+bundle_install(
+    name = "bundle",
+    excludes = {
+        "mini_portile": ["test/**/*"],
+    },
+    gemfile = "//:Gemfile",
+    gemfile_lock = "//:Gemfile.lock",
+    version = "2.1.2",
+)

--- a/examples/simple_lambda/lib/lambda.rb
+++ b/examples/simple_lambda/lib/lambda.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+BUNDLE_SETUP = 'vendor/bundle/bundler/setup'
+
+dir = File.dirname(__FILE__)
+if File.exist?("#{dir}/#{BUNDLE_SETUP}.rb")
+  require_relative 'vendor/bundle/bundler/setup'
+end
+
+require 'oj'
+require 'colored2'
+
+def handler(event:, context:)
+  Oj.dump(
+    statusCode: context[:status],
+    contentType: context[:content_type],
+    body: handler_body(event)
+  )
+end
+
+private
+
+def handler_body(event)
+  <<~BODY.gsub(/^\s+/, '')
+    <html>
+    <head>
+      <title>#{event[:title]}</title>
+    </head>
+    <body>
+      <h1>#{event[:header]}</h1>
+      <blockquote>#{event[:body]}</blockquote>
+    </body>
+    </html>
+  BODY
+end
+
+public
+
+if $PROGRAM_NAME == __FILE__
+  puts handler(
+    event: {
+      header: 'Welcome to Lambda!',
+      title: 'Lambda Demo',
+      body: 'Lambdas are cool. And so are you!'
+    },
+    context: {
+      status: 200,
+      content_type: 'text/html'
+    }
+  )
+end

--- a/examples/simple_lambda/template.yml
+++ b/examples/simple_lambda/template.yml
@@ -1,0 +1,70 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  mainInternalAPI:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: api
+      EndpointConfiguration: PRIVATE
+      TracingEnabled: true
+      DefinitionBody:
+        openapi: "3.0.0"
+        paths:
+          "/":
+            get:
+              x-amazon-apigateway-integration:
+                httpMethod: POST
+                type: aws_proxy
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ main.Arn }/invocations
+              responses: {}
+        x-amazon-apigateway-policy:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: "Allow"
+              Principal: "*"
+              Action:
+                - "execute-api:Invoke"
+              Resource: "execute-api:/*"
+            - Effect: "Deny"
+              Principal: "*"
+              Action:
+                - "execute-api:Invoke"
+              Resource: "execute-api:/*"
+              Condition:
+                StringNotEquals:
+                  aws:SourceVpc:
+                    - "vpc-11111111"
+                    - "vpc-22222222"
+                    - "vpc-33333333"
+  main:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: lib/lambda.handler
+      Runtime: ruby2.5
+      Timeout: 30
+      Tracing: "Active"
+      Role: "DEFAULT"
+      VpcConfig:
+        SecurityGroupIds:
+          - "DEFAULT"
+        SubnetIds:
+          - sub-A
+          - sub-B
+      Environment:
+        Variables:
+          TEST_ENVVAR:
+      Events:
+        InternalAPIget:
+          Type: Api
+          Properties:
+            RestApiId: !Ref mainInternalAPI
+            Path: /
+            Method: GET
+
+# Output names must match ^[a-zA-Z0-9]+$
+Outputs:
+  InternalAPIUrl:
+    Description: Endpoint for internal API
+    Value: !Sub "https://${ mainInternalAPI }.execute-api.${AWS::Region}.amazonaws.com/api"

--- a/ruby/defs.bzl
+++ b/ruby/defs.bzl
@@ -15,9 +15,14 @@ load(
     "@bazelruby_ruby_rules//ruby/private:bundle.bzl",
     _bundle_install = "bundle_install",
 )
+load(
+    "@bazelruby_ruby_rules//ruby/private/package:ruby_package.bzl",
+    _ruby_package_zip = "ruby_package_zip",
+)
 
 ruby_toolchain = _toolchain
 ruby_library = _library
 ruby_binary = _binary
 ruby_test = _test
 bundle_install = _bundle_install
+ruby_package_zip = _ruby_package_zip

--- a/ruby/private/bundle/bundle.bzl
+++ b/ruby/private/bundle/bundle.bzl
@@ -2,7 +2,7 @@ load("//ruby/private:constants.bzl", "RULES_RUBY_WORKSPACE_NAME")
 
 def install_bundler(ctx, interpreter, install_bundler, dest, version):
     args = [interpreter, install_bundler, version, dest]
-    environment = {"RUBYOPT": "--disable-gems"}
+    environment = {"RUBYOPT": "--enable-gems"}
 
     result = ctx.execute(args, environment = environment)
     if result.return_code:
@@ -38,7 +38,7 @@ def bundle_install_impl(ctx):
     # Install the Gems into the workspace
     args = [
         ctx.path(ruby),  # ruby
-        "--disable-gems",  # prevent the addition of gem installation directories to the default load path
+        "--enable-gems",  # prevent the addition of gem installation directories to the default load path
         "-I",  # Used to tell Ruby where to load the library scripts
         "bundler/lib",
         "bundler/exe/bundler",  # run
@@ -57,7 +57,7 @@ def bundle_install_impl(ctx):
     # Create the BUILD file to expose the gems to the WORKSPACE
     args = [
         ctx.path(ruby),  # ruby interpreter
-        "--disable-gems",  # prevent the addition of gem installation directories to the default load path
+        "--enable-gems",  # prevent the addition of gem installation directories to the default load path
         "-I",  # -I lib (adds this folder to $LOAD_PATH where ruby searchesf for things)
         "bundler/lib",
         "create_bundle_build_file.rb",  # The template used to created bundle file

--- a/ruby/private/package/BUILD
+++ b/ruby/private/package/BUILD
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:public"])

--- a/ruby/private/package/ruby_package.bzl
+++ b/ruby/private/package/ruby_package.bzl
@@ -1,0 +1,21 @@
+def _ruby_package_zip_impl(ctx):
+    out_file = ctx.actions.declare_file("%s.zip" % ctx.attr.name)
+
+    ctx.actions.run_shell(
+        inputs = ctx.files.srcs,
+        outputs = [out_file],
+        progress_message = "Generating bundle for %s" % (out_file.path),
+        command = "PATH=/usr/local/bin:/usr/bin:/bin:/sbin:/usr/sbin:${PATH} bundle install --path vendor/bundle; zip -rv %s vendor/bundle $@" % (out_file.path),
+        arguments = [s.path for s in ctx.files.srcs],
+    )
+
+    return [DefaultInfo(files = depset([out_file]))]
+
+ruby_package_zip = rule(
+    implementation = _ruby_package_zip_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = True,
+        ),
+    },
+)


### PR DESCRIPTION
This PR adds `ruby_package_zip` rule which grabs the sources, runs bundler into `vendor/bundle` folder and zips it all up.

It's cheating because it's downloading external resources not in a repository rule, but a regular one.

It's also using `zip` and `bundle` in the `$PATH`. 