### PR TITLE
Upstream changes from Selenium's fork

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -506,7 +506,7 @@ A unique name for this rule.
 The `Gemfile` which Bundler runs with.
 
 |`gemfile_lock` a|
-`Label, required`
+`Label, optional`
 
 The `Gemfile.lock` which Bundler runs with.
 

--- a/README.adoc
+++ b/README.adoc
@@ -143,8 +143,16 @@ ruby_bundle(
 # You can specify more than one bundle in the WORKSPACE file
 ruby_bundle(
     name = "bundle_app_shopping",
-    gemfile = "//apps/shopping:Gemfile",
-    gemfile_lock = "//apps/shopping:Gemfile.lock",
+    gemfile = "//:apps/shopping/Gemfile",
+    gemfile_lock = "//:apps/shopping/Gemfile.lock",
+)
+
+# You can also install from Gemfile using `gemspec`.
+ruby_bundle(
+    name = "bundle_gemspec",
+    srcs = ["//:lib/my_gem/my_gem.gemspec"],
+    gemfile = "//:lib/my_gem/Gemfile",
+    gemfile_lock = "//:lib/my_gem/Gemfile.lock",
 )
 ----
 
@@ -477,6 +485,7 @@ ruby_bundle(
     bundler_version = "2.1.4",
     includes = {},
     excludes = {},
+    srcs = [],
     vendor_cache = False,
     ruby_sdk = "@org_ruby_lang_ruby_toolchain",
     ruby_interpreter = "@org_ruby_lang_ruby_toolchain//:ruby",
@@ -503,6 +512,11 @@ The `Gemfile.lock` which Bundler runs with.
 
 NOTE: This rule never updates the `Gemfile.lock`. It is your responsibility to generate/update `Gemfile.lock`
 
+|`srcs` a|
+`List of Labels, optional`
+
+List of additional files required for Bundler to install gems. This could usually include `*.gemspec` files.
+
 |`vendor_cache` a|
 `Bool, optional`
 
@@ -528,10 +542,6 @@ List of glob patterns per gem to be excluded from the library. Keys are the name
 2+<|And other https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes[common attributes].
 |===
 
-
-==== Limitations
-
-Installing using a `Gemfile` that uses the `gemspec` keyword is not currently supported.
 
 ==== Conventions
 

--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -247,6 +247,9 @@ class BundleBuildFileGenerator
   end
 
   def register_gem(spec, template_out, bundle_lib_paths, bundle_binaries)
+    # Do not register local gems
+    return if spec.source.path?
+
     gem_path = GEM_PATH[ruby_version, spec.name, spec.version]
     spec_path = SPEC_PATH[ruby_version, spec.name, spec.version]
     base_dir = "lib/ruby/#{ruby_version}"

--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -65,8 +65,10 @@ ALL_GEMS
 #
 # Since OS platform is unlikely to change between Bazel builds on the same machine,
 # `#{gem_name}-#{gem_version}*` would be sufficient to narrow down matches to at most one.
+#
+# Library path differs across implementations as `lib/ruby` on MRI and `lib/jruby` on JRuby.
 GEM_PATH = ->(ruby_version, gem_name, gem_version) do
-  Dir.glob("lib/ruby/#{ruby_version}/gems/#{gem_name}-#{gem_version}*").first
+  Dir.glob("lib/#{RbConfig::CONFIG['RUBY_INSTALL_NAME']}/#{ruby_version}/gems/#{gem_name}-#{gem_version}*").first
 end
 
 # For ordinary gems, this path is like 'lib/ruby/3.0.0/specifications/rspec-3.10.0.gemspec'.
@@ -76,8 +78,10 @@ end
 #
 # Since OS platform is unlikely to change between Bazel builds on the same machine,
 # `#{gem_name}-#{gem_version}*.gemspec` would be sufficient to narrow down matches to at most one.
+#
+# Library path differs across implementations as `lib/ruby` on MRI and `lib/jruby` on JRuby.
 SPEC_PATH = ->(ruby_version, gem_name, gem_version) do
-  Dir.glob("lib/ruby/#{ruby_version}/specifications/#{gem_name}-#{gem_version}*.gemspec").first
+  Dir.glob("lib/#{RbConfig::CONFIG['RUBY_INSTALL_NAME']}/#{ruby_version}/specifications/#{gem_name}-#{gem_version}*.gemspec").first
 end
 
 require 'bundler'

--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -176,14 +176,14 @@ class BundleBuildFileGenerator
   def initialize(workspace_name:,
                  repo_name:,
                  build_file: 'BUILD.bazel',
-                 gemfile_lock: 'Gemfile.lock',
+                 gemfile: 'Gemfile',
                  includes: nil,
                  excludes: nil,
                  additional_require_paths: nil)
     @workspace_name = workspace_name
     @repo_name      = repo_name
     @build_file     = build_file
-    @gemfile_lock   = gemfile_lock
+    @gemfile_lock   = "#{gemfile}.lock"
     @includes       = includes
     @excludes       = excludes
     # This attribute returns 0 as the third minor version number, which happens to be
@@ -313,14 +313,14 @@ end
 # ruby ./create_bundle_build_file.rb "BUILD.bazel" "Gemfile.lock" "repo_name" "{}" "{}" "wsp_name"
 if $0 == __FILE__
   if ARGV.length != 6
-    warn("USAGE: #{$0} BUILD.bazel Gemfile.lock repo-name {includes-json} {excludes-json} workspace-name".orange)
+    warn("USAGE: #{$0} BUILD.bazel Gemfile repo-name {includes-json} {excludes-json} workspace-name".orange)
     exit(1)
   end
 
-  build_file, gemfile_lock, repo_name, includes, excludes, workspace_name, * = *ARGV
+  build_file, gemfile, repo_name, includes, excludes, workspace_name, * = *ARGV
 
   BundleBuildFileGenerator.new(build_file:     build_file,
-                               gemfile_lock:   gemfile_lock,
+                               gemfile:        gemfile,
                                repo_name:      repo_name,
                                includes:       JSON.parse(includes),
                                excludes:       JSON.parse(excludes),

--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -60,10 +60,10 @@ ALL_GEMS
 
 # For ordinary gems, this path is like 'lib/ruby/3.0.0/gems/rspec-3.10.0'.
 # For gems with native extension installed via prebuilt packages, the last part of this path can
-# contain an OS-specific suffix like 'grpc-1.38.0-universal-darwin' or 'grpc-1.38.0-x86_64-linux' 
+# contain an OS-specific suffix like 'grpc-1.38.0-universal-darwin' or 'grpc-1.38.0-x86_64-linux'
 # instead of 'grpc-1.38.0'.
-# 
-# Since OS platform is unlikely to change between Bazel builds on the same machine, 
+#
+# Since OS platform is unlikely to change between Bazel builds on the same machine,
 # `#{gem_name}-#{gem_version}*` would be sufficient to narrow down matches to at most one.
 GEM_PATH = ->(ruby_version, gem_name, gem_version) do
   Dir.glob("lib/ruby/#{ruby_version}/gems/#{gem_name}-#{gem_version}*").first
@@ -71,7 +71,7 @@ end
 
 # For ordinary gems, this path is like 'lib/ruby/3.0.0/specifications/rspec-3.10.0.gemspec'.
 # For gems with native extension installed via prebuilt packages, the last part of this path can
-# contain an OS-specific suffix like 'grpc-1.38.0-universal-darwin.gemspec' or 
+# contain an OS-specific suffix like 'grpc-1.38.0-universal-darwin.gemspec' or
 # 'grpc-1.38.0-x86_64-linux.gemspec' instead of 'grpc-1.38.0.gemspec'.
 #
 # Since OS platform is unlikely to change between Bazel builds on the same machine,

--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -180,14 +180,14 @@ class BundleBuildFileGenerator
   def initialize(workspace_name:,
                  repo_name:,
                  build_file: 'BUILD.bazel',
-                 gemfile: 'Gemfile',
+                 gemfile_lock: 'Gemfile.lock',
                  includes: nil,
                  excludes: nil,
                  additional_require_paths: nil)
     @workspace_name = workspace_name
     @repo_name      = repo_name
     @build_file     = build_file
-    @gemfile_lock   = "#{gemfile}.lock"
+    @gemfile_lock   = gemfile_lock
     @includes       = includes
     @excludes       = excludes
     # This attribute returns 0 as the third minor version number, which happens to be
@@ -320,14 +320,14 @@ end
 # ruby ./create_bundle_build_file.rb "BUILD.bazel" "Gemfile.lock" "repo_name" "{}" "{}" "wsp_name"
 if $0 == __FILE__
   if ARGV.length != 6
-    warn("USAGE: #{$0} BUILD.bazel Gemfile repo-name {includes-json} {excludes-json} workspace-name".orange)
+    warn("USAGE: #{$0} BUILD.bazel Gemfile.lock repo-name {includes-json} {excludes-json} workspace-name".orange)
     exit(1)
   end
 
-  build_file, gemfile, repo_name, includes, excludes, workspace_name, * = *ARGV
+  build_file, gemfile_lock, repo_name, includes, excludes, workspace_name, * = *ARGV
 
   BundleBuildFileGenerator.new(build_file:     build_file,
-                               gemfile:        gemfile,
+                               gemfile_lock:   gemfile_lock,
                                repo_name:      repo_name,
                                includes:       JSON.parse(includes),
                                excludes:       JSON.parse(excludes),

--- a/ruby/private/bundle/def.bzl
+++ b/ruby/private/bundle/def.bzl
@@ -137,6 +137,11 @@ def bundle_install(runtime_ctx, previous_result):
         return result
 
 def generate_bundle_build_file(runtime_ctx, previous_result):
+    if runtime_ctx.ctx.attr.gemfile_lock:
+        gemfile_lock = runtime_ctx.ctx.attr.gemfile_lock.name
+    else:
+        gemfile_lock = "{}.lock".format(runtime_ctx.ctx.attr.gemfile.name)
+
     # Create the BUILD file to expose the gems to the WORKSPACE
     # USAGE: ./create_bundle_build_file.rb BUILD.bazel Gemfile.lock repo-name [excludes-json] workspace-name
     args = [
@@ -146,7 +151,7 @@ def generate_bundle_build_file(runtime_ctx, previous_result):
         "bundler/lib",
         SCRIPT_BUILD_FILE_GENERATOR,  # The template used to created bundle file
         "BUILD.bazel",  # Bazel build file (can be empty)
-        runtime_ctx.ctx.attr.gemfile.name,  # Gemfile -> Gemfile.lock where we list all direct and transitive dependencies
+        gemfile_lock,  # Gemfile.lock where we list all direct and transitive dependencies
         runtime_ctx.ctx.name,  # Name of the target
         repr(runtime_ctx.ctx.attr.includes),
         repr(runtime_ctx.ctx.attr.excludes),

--- a/ruby/private/constants.bzl
+++ b/ruby/private/constants.bzl
@@ -79,6 +79,9 @@ BUNDLE_ATTRS = {
     "gemfile_lock": attr.label(
         allow_single_file = True,
     ),
+    "srcs": attr.label_list(
+        allow_files = True,
+    ),
     "vendor_cache": attr.bool(
         doc = "Symlink the vendor directory into the Bazel build space, this allows Bundler to access vendored Gems",
     ),

--- a/ruby/private/toolchains/repository_context.bzl
+++ b/ruby/private/toolchains/repository_context.bzl
@@ -45,6 +45,8 @@ def ruby_repository_context(repository_ctx, interpreter_path):
     rel_interpreter_path = str(interpreter_path)
     if rel_interpreter_path.startswith("/"):
         rel_interpreter_path = rel_interpreter_path[1:]
+    elif rel_interpreter_path.startswith("C:/"):
+        rel_interpreter_path = rel_interpreter_path[3:]
 
     return struct(
         # Location of the interpreter

--- a/ruby/private/toolchains/ruby_runtime.bzl
+++ b/ruby/private/toolchains/ruby_runtime.bzl
@@ -47,6 +47,9 @@ def _list_libdirs(ruby):
 def _install_dirs(ctx, ruby, *names):
     paths = sorted([ruby.rbconfig(ruby, name) for name in names])
 
+    # JRuby reports some of the directories as nulls.
+    paths = [path for path in paths if path]
+
     # Sometimes we end up with the same directory multiple times
     # so make sure paths are unique by converting it to set.
     # For example, this is what we have on Fedora 34:

--- a/ruby/private/toolchains/ruby_runtime.bzl
+++ b/ruby/private/toolchains/ruby_runtime.bzl
@@ -32,6 +32,8 @@ def _relativate(path):
     # TODO(yugui) support windows
     if path.startswith("/"):
         return path[1:]
+    elif path.startswith("C:/"):
+        return path[3:]
     else:
         return path
 

--- a/ruby/private/toolchains/ruby_runtime.bzl
+++ b/ruby/private/toolchains/ruby_runtime.bzl
@@ -44,6 +44,16 @@ def _list_libdirs(ruby):
 
 def _install_dirs(ctx, ruby, *names):
     paths = sorted([ruby.rbconfig(ruby, name) for name in names])
+
+    # Sometimes we end up with the same directory multiple times
+    # so make sure paths are unique by converting it to set.
+    # For example, this is what we have on Fedora 34:
+    # $ ruby -rrbconfig -e "p RbConfig::CONFIG['rubyhdrdir']"
+    # "/usr/include"
+    # $ ruby -rrbconfig -e "p RbConfig::CONFIG['rubyarchhdrdir']"
+    # "/usr/include"
+    paths = depset(paths).to_list()
+
     rel_paths = [_relativate(path) for path in paths]
     for i, (path, rel_path) in enumerate(zip(paths, rel_paths)):
         if not _is_subpath(path, paths[:i]):


### PR DESCRIPTION
This PR introduces multiple changes that are necessary to make Ruby rules work in Selenium https://github.com/SeleniumHQ/selenium. Historically, we've been maintaining our fork of https://github.com/coinbase/rules_ruby but would prefer to upstream the changes to Bazelruby.

You should be able to review this PR by commit, but let me go through the changes here too:

1. Allow to symlink additional files for `ruby_bundle()` via `src` attribute. This allows to specify `*.gemspec` files and use Bazel for regular Ruby gem development. [Example](https://github.com/SeleniumHQ/selenium/blob/19293e3fadfb16623c20e3c53453001512105c58/WORKSPACE#L280-L289)
2. No longer require `gemfile_lock` for `ruby_bundle()`. This file is usually gitignored in Ruby gems.
3. Multiple fixes to make Ruby `host` SDK load on Windows, Linux and JRuby. Windows support is pretty much non-existent, but at least Bazel now loads with Ruby SDK in WORKSPACE.
4. Local gems installed using `gem 'foo', path: 'foo'` are now skipped when generating `BUILD.bazel` for `ruby_bundle()`. There seems to be no need to include them.