### PR TITLE
Support Git source in Gemfile

### DIFF
--- a/examples/simple_script/Gemfile
+++ b/examples/simple_script/Gemfile
@@ -5,5 +5,5 @@ source 'https://rubygems.org'
 gem 'awesome_print'
 gem 'colored2'
 gem 'rspec', '~> 3.7.0'
-gem 'rspec-its'
+gem 'rspec-its', github: "rspec/rspec-its", ref: "3d36b4a7b004ffa204a0e392f27c8b6b0b674ecf" # v1.3.0
 gem 'rubocop'

--- a/examples/simple_script/Gemfile.lock
+++ b/examples/simple_script/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/rspec/rspec-its.git
+  revision: 3d36b4a7b004ffa204a0e392f27c8b6b0b674ecf
+  ref: 3d36b4a7b004ffa204a0e392f27c8b6b0b674ecf
+  specs:
+    rspec-its (1.3.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -20,9 +29,6 @@ GEM
     rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
-    rspec-its (1.3.0)
-      rspec-core (>= 3.0.0)
-      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
@@ -48,7 +54,7 @@ DEPENDENCIES
   awesome_print
   colored2
   rspec (~> 3.7.0)
-  rspec-its
+  rspec-its!
   rubocop
 
 BUNDLED WITH

--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -252,9 +252,9 @@ class BundleBuildFileGenerator
     # Do not register local gems
     return if spec.source.path?
 
+    base_dir = "lib/ruby/#{ruby_version}"
     if spec.source.is_a?(Bundler::Source::Git)
       stub = spec.source.specs.find { |s| s.name == spec.name }.stub
-      base_dir = "lib/ruby/#{ruby_version}"
       gem_path = "#{base_dir}/bundler/gems/#{Pathname(stub.full_gem_path).relative_path_from(stub.base_dir)}"
       spec_path = "#{base_dir}/bundler/gems/#{Pathname(stub.loaded_from).relative_path_from(stub.base_dir)}"
 
@@ -263,7 +263,6 @@ class BundleBuildFileGenerator
     else
       gem_path = GEM_PATH[ruby_version, spec.name, spec.version]
       spec_path = SPEC_PATH[ruby_version, spec.name, spec.version]
-      base_dir = "lib/ruby/#{ruby_version}"
 
       # paths to register to $LOAD_PATH
       require_paths = Gem::StubSpecification.gemspec_stub(spec_path, base_dir, "#{base_dir}/gems").require_paths


### PR DESCRIPTION
When use Git source in Gemfile: 

```rb
gem 'rspec-its', github: "rspec/rspec-its", ref: "3d36b4a7b004ffa204a0e392f27c8b6b0b674ecf" # v1.3.0
```

Occur error 

```
$ cd examples/simple_script
$ bazel test //...
...
INFO: Repository bundle instantiated at:
  /work/examples/simple_script/WORKSPACE:22:12: in <toplevel>
Repository rule ruby_bundle_install defined at:
  /root/.cache/bazel/_bazel_root/7f81b7228d5513bd8ae9460589a2de46/external/bazelruby_rules_ruby/ruby/private/bundle/def.bzl:200:38: in <toplevel>
ERROR: An error occurred during the fetch of repository 'bundle':
   Traceback (most recent call last):
	File "/root/.cache/bazel/_bazel_root/7f81b7228d5513bd8ae9460589a2de46/external/bazelruby_rules_ruby/ruby/private/bundle/def.bzl", line 198, column 31, in _ruby_bundle_impl
		generate_bundle_build_file(runtime_ctx, result)
	File "/root/.cache/bazel/_bazel_root/7f81b7228d5513bd8ae9460589a2de46/external/bazelruby_rules_ruby/ruby/private/bundle/def.bzl", line 163, column 13, in generate_bundle_build_file
		fail("build file generation failed: %s%s" % (result.stdout, result.stderr))
Error in fail: build file generation failed: registering gem diff-lcs with binaries: ["bin/htmldiff", "bin/ldiff"]
registering gem parser with binaries: ["bin/ruby-parse", "bin/ruby-rewrite"]
registering gem rspec-core with binaries: ["bin/rspec"]
/root/.cache/bazel/_bazel_root/7f81b7228d5513bd8ae9460589a2de46/external/org_ruby_lang_ruby_toolchain/build/lib/ruby/3.0.0/rubygems/stub_specification.rb:113:in `initialize': no implicit conversion of nil into String (TypeError)
	from /root/.cache/bazel/_bazel_root/7f81b7228d5513bd8ae9460589a2de46/external/org_ruby_lang_ruby_toolchain/build/lib/ruby/3.0.0/rubygems/stub_specification.rb:113:in `open'
	from /root/.cache/bazel/_bazel_root/7f81b7228d5513bd8ae9460589a2de46/external/org_ruby_lang_ruby_toolchain/build/lib/ruby/3.0.0/rubygems/stub_specification.rb:113:in `data'
	from /root/.cache/bazel/_bazel_root/7f81b7228d5513bd8ae9460589a2de46/external/org_ruby_lang_ruby_toolchain/build/lib/ruby/3.0.0/rubygems/stub_specification.rb:169:in `extensions'
	from /root/.cache/bazel/_bazel_root/7f81b7228d5513bd8ae9460589a2de46/external/org_ruby_lang_ruby_toolchain/build/lib/ruby/3.0.0/rubygems/basic_specification.rb:330:in `have_extensions?'
	from /root/.cache/bazel/_bazel_root/7f81b7228d5513bd8ae9460589a2de46/external/org_ruby_lang_ruby_toolchain/build/lib/ruby/3.0.0/rubygems/basic_specification.rb:247:in `require_paths'
	from create_bundle_build_file.rb:260:in `register_gem'
	from create_bundle_build_file.rb:215:in `block in generate!'
	from create_bundle_build_file.rb:215:in `each'
	from create_bundle_build_file.rb:215:in `generate!'
	from create_bundle_build_file.rb:332:in `<main>'
ERROR: /work/examples/simple_script/WORKSPACE:22:12: fetching ruby_bundle_install rule //external:bundle: Traceback (most recent call last):
	File "/root/.cache/bazel/_bazel_root/7f81b7228d5513bd8ae9460589a2de46/external/bazelruby_rules_ruby/ruby/private/bundle/def.bzl", line 198, column 31, in _ruby_bundle_impl
		generate_bundle_build_file(runtime_ctx, result)
	File "/root/.cache/bazel/_bazel_root/7f81b7228d5513bd8ae9460589a2de46/external/bazelruby_rules_ruby/ruby/private/bundle/def.bzl", line 163, column 13, in generate_bundle_build_file
		fail("build file generation failed: %s%s" % (result.stdout, result.stderr))
Error in fail: build file generation failed: registering gem diff-lcs with binaries: ["bin/htmldiff", "bin/ldiff"]
...
```

Reason is gem's path is wrong to create BUILD file for git source gem:

```rb
GEM_PATH = ->(ruby_version, gem_name, gem_version) do
  Dir.glob("lib/#{RbConfig::CONFIG['RUBY_INSTALL_NAME']}/#{ruby_version}/gems/#{gem_name}-#{gem_version}*").first
end

SPEC_PATH = ->(ruby_version, gem_name, gem_version) do
  Dir.glob("lib/#{RbConfig::CONFIG['RUBY_INSTALL_NAME']}/#{ruby_version}/specifications/#{gem_name}-#{gem_version}*.gemspec").first
end

...

    gem_path = GEM_PATH[ruby_version, spec.name, spec.version]
    spec_path = SPEC_PATH[ruby_version, spec.name, spec.version]
```

So, build `gem_path` and `spec_path` using [`StubSpecification` object](https://github.com/rubygems/rubygems/blob/bundler-v2.2.7/bundler/lib/bundler/source/git.rb#L322) of `spec` variable.
