### PR TITLE
Add ruby versioning support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -97,12 +97,7 @@ git_repository(
     branch = "master"
 )
 
-load(
-    "@rules_ruby//ruby:deps.bzl",
-    "rules_ruby_dependencies",
-    "rules_ruby_select_sdk",
-)
-
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 rules_ruby_dependencies()
 
 #———————————————————————————————————————————————————————————————————————
@@ -113,7 +108,8 @@ rules_ruby_dependencies()
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
-rules_ruby_select_sdk(version = "3.0.2")
+load("@rules_ruby//ruby:defs.bzl", "register_ruby_toolchain")
+register_ruby_toolchain(name = "ruby-3.0", version = "3.0.2")
 
 #———————————————————————————————————————————————————————————————————————
 # Now, load the ruby_bundle rule & install gems specified in the Gemfile
@@ -486,8 +482,7 @@ ruby_bundle(
     excludes = {},
     srcs = [],
     vendor_cache = False,
-    ruby_sdk = "@org_ruby_lang_ruby_toolchain",
-    ruby_interpreter = "@org_ruby_lang_ruby_toolchain//:ruby",
+    ruby_interpreter = "@ruby-system//:ruby",
 )
 ----
 

--- a/README.adoc
+++ b/README.adoc
@@ -92,13 +92,13 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 #———————————————————————————————————————————————————————————————————————
 
 git_repository(
-    name = "bazelruby_rules_ruby",
+    name = "rules_ruby",
     remote = "https://github.com/bazelruby/rules_ruby.git",
     branch = "master"
 )
 
 load(
-    "@bazelruby_rules_ruby//ruby:deps.bzl",
+    "@rules_ruby//ruby:deps.bzl",
     "rules_ruby_dependencies",
     "rules_ruby_select_sdk",
 )
@@ -120,7 +120,7 @@ rules_ruby_select_sdk(version = "3.0.2")
 #———————————————————————————————————————————————————————————————————————
 
 load(
-    "@bazelruby_rules_ruby//ruby:defs.bzl",
+    "@rules_ruby//ruby:defs.bzl",
     "ruby_bundle",
 )
 
@@ -170,7 +170,7 @@ Add `ruby_library`, `ruby_binary`, `ruby_rspec` or `ruby_test` into your `BUILD.
 #———————————————————————————————————————————————————————————————————————
 
 load(
-    "@bazelruby_rules_ruby//ruby:defs.bzl",
+    "@rules_ruby//ruby:defs.bzl",
     "ruby_binary",
     "ruby_library",
     "ruby_test",
@@ -215,7 +215,7 @@ Use `ruby_gem` rule to package any number of ruby files or folders into a Ruby-G
 [source,python]
 ----
 load(
-    "@bazelruby_rules_ruby//ruby:defs.bzl",
+    "@rules_ruby//ruby:defs.bzl",
     "ruby_gem",
 )
 
@@ -555,7 +555,7 @@ List of glob patterns per gem to be excluded from the library. Keys are the name
 
 [source,python]
 ----
-load("@bazelruby_rules_ruby//ruby:defs.bzl", "ruby_bundle")
+load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "gems",
@@ -572,7 +572,7 @@ your workspace. The name should match the name of the bundle.
 
 [source,python]
 ----
-load("@bazelruby_rules_ruby//ruby:defs.bzl", "ruby_bundle")
+load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
 
 workspace(
     name = "my_wksp",

--- a/README.adoc
+++ b/README.adoc
@@ -108,8 +108,8 @@ rules_ruby_dependencies()
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
-load("@rules_ruby//ruby:defs.bzl", "register_ruby_toolchain")
-register_ruby_toolchain(name = "ruby-3.0", version = "3.0.2")
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
+rules_ruby_register_toolchains("3.0.2")
 
 #———————————————————————————————————————————————————————————————————————
 # Now, load the ruby_bundle rule & install gems specified in the Gemfile

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "bazelruby_rules_ruby")
+workspace(name = "rules_ruby")
 
 load("@//ruby:deps.bzl", "rules_ruby_dependencies", "rules_ruby_select_sdk")
 
@@ -15,12 +15,12 @@ versions.check("3.4.1")
 rules_ruby_select_sdk("3.0.2")
 
 local_repository(
-    name = "bazelruby_rules_ruby_ruby_tests_testdata_another_workspace",
+    name = "rules_ruby_ruby_tests_testdata_another_workspace",
     path = "ruby/tests/testdata/another_workspace",
 )
 
 local_repository(
-    name = "bazelruby_rules_ruby_ruby_tests_testdata_bundle_includes_workspace",
+    name = "rules_ruby_ruby_tests_testdata_bundle_includes_workspace",
     path = "ruby/tests/testdata/bundle_includes_workspace",
 )
 
@@ -95,7 +95,7 @@ container_pull(
     repository = "library/ruby",
 )
 
-load("@bazelruby_rules_ruby//ruby:defs.bzl", "ruby_bundle")
+load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,9 +12,8 @@ load("@bazel_skylib//lib:versions.bzl", "versions")
 
 versions.check("3.4.1")
 
-load("@rules_ruby//ruby:defs.bzl", "register_ruby_toolchain")
-register_ruby_toolchain(name = "ruby-system")
-register_ruby_toolchain(name = "ruby-3.0", version = "3.0.2")
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
+rules_ruby_register_toolchains("3.0.2")
 
 local_repository(
     name = "rules_ruby_ruby_tests_testdata_another_workspace",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,6 @@
 workspace(name = "rules_ruby")
 
-load("@//ruby:deps.bzl", "rules_ruby_dependencies", "rules_ruby_select_sdk")
+load("@//ruby:deps.bzl", "rules_ruby_dependencies")
 
 rules_ruby_dependencies()
 
@@ -12,7 +12,9 @@ load("@bazel_skylib//lib:versions.bzl", "versions")
 
 versions.check("3.4.1")
 
-rules_ruby_select_sdk("3.0.2")
+load("@rules_ruby//ruby:defs.bzl", "register_ruby_toolchain")
+register_ruby_toolchain(name = "ruby-system")
+register_ruby_toolchain(name = "ruby-3.0", version = "3.0.2")
 
 local_repository(
     name = "rules_ruby_ruby_tests_testdata_another_workspace",

--- a/examples/example_gem/BUILD.bazel
+++ b/examples/example_gem/BUILD.bazel
@@ -1,5 +1,5 @@
 load(
-    "@bazelruby_rules_ruby//ruby:defs.bzl",
+    "@rules_ruby//ruby:defs.bzl",
     "ruby_gem",
 )
 

--- a/examples/example_gem/WORKSPACE
+++ b/examples/example_gem/WORKSPACE
@@ -10,8 +10,8 @@ local_repository(
 load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 rules_ruby_dependencies()
 
-load("@rules_ruby//ruby:defs.bzl", "register_ruby_toolchain")
-register_ruby_toolchain(name = "ruby-3.0", version = "3.0.2")
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
+rules_ruby_register_toolchains("3.0.2")
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 

--- a/examples/example_gem/WORKSPACE
+++ b/examples/example_gem/WORKSPACE
@@ -1,14 +1,14 @@
-workspace(name = "bazelruby_rules_ruby_example_gem")
+workspace(name = "rules_ruby_example_gem")
 
 # Importing rules_ruby from the parent directory for developing
 # rules_ruby itself...
 local_repository(
-    name = "bazelruby_rules_ruby",
+    name = "rules_ruby",
     path = "../..",
 )
 
 load(
-    "@bazelruby_rules_ruby//ruby:deps.bzl",
+    "@rules_ruby//ruby:deps.bzl",
     "rules_ruby_dependencies",
     "rules_ruby_select_sdk",
 )

--- a/examples/example_gem/WORKSPACE
+++ b/examples/example_gem/WORKSPACE
@@ -7,15 +7,11 @@ local_repository(
     path = "../..",
 )
 
-load(
-    "@rules_ruby//ruby:deps.bzl",
-    "rules_ruby_dependencies",
-    "rules_ruby_select_sdk",
-)
-
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 rules_ruby_dependencies()
 
-rules_ruby_select_sdk("3.0.2")
+load("@rules_ruby//ruby:defs.bzl", "register_ruby_toolchain")
+register_ruby_toolchain(name = "ruby-3.0", version = "3.0.2")
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 

--- a/examples/example_gem/lib/BUILD
+++ b/examples/example_gem/lib/BUILD
@@ -1,5 +1,5 @@
 load(
-    "@bazelruby_rules_ruby//ruby:defs.bzl",
+    "@rules_ruby//ruby:defs.bzl",
     "ruby_library",
 )
 

--- a/examples/example_gem/lib/foo/BUILD
+++ b/examples/example_gem/lib/foo/BUILD
@@ -1,5 +1,5 @@
 load(
-    "@bazelruby_rules_ruby//ruby:defs.bzl",
+    "@rules_ruby//ruby:defs.bzl",
     "ruby_library",
 )
 

--- a/examples/simple_rails_api/BUILD
+++ b/examples/simple_rails_api/BUILD
@@ -1,5 +1,5 @@
 load(
-    "@bazelruby_rules_ruby//ruby:defs.bzl",
+    "@rules_ruby//ruby:defs.bzl",
     "ruby_binary",
 )
 

--- a/examples/simple_rails_api/WORKSPACE
+++ b/examples/simple_rails_api/WORKSPACE
@@ -10,8 +10,8 @@ local_repository(
 load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 rules_ruby_dependencies()
 
-load("@rules_ruby//ruby:defs.bzl", "register_ruby_toolchain")
-register_ruby_toolchain(name = "ruby-3.0", version = "3.0.2")
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
+rules_ruby_register_toolchains("3.0.2")
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 

--- a/examples/simple_rails_api/WORKSPACE
+++ b/examples/simple_rails_api/WORKSPACE
@@ -7,15 +7,11 @@ local_repository(
     path = "../..",
 )
 
-load(
-    "@rules_ruby//ruby:deps.bzl",
-    "rules_ruby_dependencies",
-    "rules_ruby_select_sdk",
-)
-
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 rules_ruby_dependencies()
 
-rules_ruby_select_sdk(version = "3.0.2")
+load("@rules_ruby//ruby:defs.bzl", "register_ruby_toolchain")
+register_ruby_toolchain(name = "ruby-3.0", version = "3.0.2")
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 

--- a/examples/simple_rails_api/WORKSPACE
+++ b/examples/simple_rails_api/WORKSPACE
@@ -1,14 +1,14 @@
-workspace(name = "bazelruby_rules_ruby_example")
+workspace(name = "rules_ruby_example")
 
 # Importing rules_ruby from the parent directory for developing
 # rules_ruby itself...
 local_repository(
-    name = "bazelruby_rules_ruby",
+    name = "rules_ruby",
     path = "../..",
 )
 
 load(
-    "@bazelruby_rules_ruby//ruby:deps.bzl",
+    "@rules_ruby//ruby:deps.bzl",
     "rules_ruby_dependencies",
     "rules_ruby_select_sdk",
 )
@@ -21,7 +21,7 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-load("@bazelruby_rules_ruby//ruby:defs.bzl", "ruby_bundle")
+load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",

--- a/examples/simple_script/BUILD.bazel
+++ b/examples/simple_script/BUILD.bazel
@@ -1,5 +1,5 @@
 load(
-    "@bazelruby_rules_ruby//ruby:defs.bzl",
+    "@rules_ruby//ruby:defs.bzl",
     "ruby_binary",
     "ruby_rspec",
     "ruby_rubocop",

--- a/examples/simple_script/WORKSPACE
+++ b/examples/simple_script/WORKSPACE
@@ -7,17 +7,12 @@ local_repository(
     path = "../..",
 )
 
-load(
-    "@rules_ruby//ruby:deps.bzl",
-    "rules_ruby_dependencies",
-    "rules_ruby_select_sdk",
-)
-
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 rules_ruby_dependencies()
 
-rules_ruby_select_sdk(version = "3.0.2")
+load("@rules_ruby//ruby:defs.bzl", "register_ruby_toolchain", "ruby_bundle")
 
-load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
+register_ruby_toolchain(name = "ruby-3.0", version = "3.0.2")
 
 ruby_bundle(
     name = "bundle",

--- a/examples/simple_script/WORKSPACE
+++ b/examples/simple_script/WORKSPACE
@@ -7,12 +7,11 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies", "rules_ruby_register_toolchains")
 rules_ruby_dependencies()
+rules_ruby_register_toolchains("3.0.2")
 
-load("@rules_ruby//ruby:defs.bzl", "register_ruby_toolchain", "ruby_bundle")
-
-register_ruby_toolchain(name = "ruby-3.0", version = "3.0.2")
+load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",

--- a/examples/simple_script/WORKSPACE
+++ b/examples/simple_script/WORKSPACE
@@ -1,14 +1,14 @@
-workspace(name = "bazelruby_rules_ruby_example")
+workspace(name = "rules_ruby_example")
 
 # Importing rules_ruby from the parent directory for developing
 # rules_ruby itself...
 local_repository(
-    name = "bazelruby_rules_ruby",
+    name = "rules_ruby",
     path = "../..",
 )
 
 load(
-    "@bazelruby_rules_ruby//ruby:deps.bzl",
+    "@rules_ruby//ruby:deps.bzl",
     "rules_ruby_dependencies",
     "rules_ruby_select_sdk",
 )
@@ -17,7 +17,7 @@ rules_ruby_dependencies()
 
 rules_ruby_select_sdk(version = "3.0.2")
 
-load("@bazelruby_rules_ruby//ruby:defs.bzl", "ruby_bundle")
+load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",

--- a/examples/simple_script/lib/BUILD
+++ b/examples/simple_script/lib/BUILD
@@ -1,5 +1,5 @@
 load(
-    "@bazelruby_rules_ruby//ruby:defs.bzl",
+    "@rules_ruby//ruby:defs.bzl",
     "ruby_library",
 )
 

--- a/examples/simple_script_vendored/BUILD.bazel
+++ b/examples/simple_script_vendored/BUILD.bazel
@@ -1,5 +1,5 @@
 load(
-    "@bazelruby_rules_ruby//ruby:defs.bzl",
+    "@rules_ruby//ruby:defs.bzl",
     "ruby_binary",
     "ruby_rspec",
     "ruby_rubocop",

--- a/examples/simple_script_vendored/WORKSPACE
+++ b/examples/simple_script_vendored/WORKSPACE
@@ -10,17 +10,12 @@ local_repository(
     path = "../..",
 )
 
-load(
-    "@rules_ruby//ruby:deps.bzl",
-    "rules_ruby_dependencies",
-    "rules_ruby_select_sdk",
-)
-
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 rules_ruby_dependencies()
 
-rules_ruby_select_sdk(version = "2.7.1")
+load("@rules_ruby//ruby:defs.bzl", "register_ruby_toolchain", "ruby_bundle")
 
-load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
+register_ruby_toolchain(name = "ruby-2.7", version = "2.7.1")
 
 ruby_bundle(
     name = "bundle",

--- a/examples/simple_script_vendored/WORKSPACE
+++ b/examples/simple_script_vendored/WORKSPACE
@@ -1,17 +1,17 @@
 workspace(
-    name = "bazelruby_rules_ruby_example",
+    name = "rules_ruby_example",
     managed_directories = {"@bundle": ["vendor"]},
 )
 
 # Importing rules_ruby from the parent directory for developing
 # rules_ruby itself...
 local_repository(
-    name = "bazelruby_rules_ruby",
+    name = "rules_ruby",
     path = "../..",
 )
 
 load(
-    "@bazelruby_rules_ruby//ruby:deps.bzl",
+    "@rules_ruby//ruby:deps.bzl",
     "rules_ruby_dependencies",
     "rules_ruby_select_sdk",
 )
@@ -20,7 +20,7 @@ rules_ruby_dependencies()
 
 rules_ruby_select_sdk(version = "2.7.1")
 
-load("@bazelruby_rules_ruby//ruby:defs.bzl", "ruby_bundle")
+load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",

--- a/examples/simple_script_vendored/WORKSPACE
+++ b/examples/simple_script_vendored/WORKSPACE
@@ -10,12 +10,11 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies", "rules_ruby_register_toolchains")
 rules_ruby_dependencies()
+rules_ruby_register_toolchains("2.7.1")
 
-load("@rules_ruby//ruby:defs.bzl", "register_ruby_toolchain", "ruby_bundle")
-
-register_ruby_toolchain(name = "ruby-2.7", version = "2.7.1")
+load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",

--- a/examples/simple_script_vendored/lib/BUILD
+++ b/examples/simple_script_vendored/lib/BUILD
@@ -1,5 +1,5 @@
 load(
-    "@bazelruby_rules_ruby//ruby:defs.bzl",
+    "@rules_ruby//ruby:defs.bzl",
     "ruby_library",
 )
 

--- a/ruby/defs.bzl
+++ b/ruby/defs.bzl
@@ -7,10 +7,6 @@ load(
     _library = "ruby_library",
 )
 load(
-    "@rules_ruby//ruby/private:sdk.bzl",
-    _register_ruby_toolchain = "register_ruby_toolchain"
-)
-load(
     "@rules_ruby//ruby/private:binary.bzl",
     _binary = "ruby_binary",
     _test = "ruby_test",
@@ -35,7 +31,6 @@ load(
     _gemspec = "gemspec",
 )
 
-register_ruby_toolchain = _register_ruby_toolchain
 ruby_toolchain = _toolchain
 ruby_library = _library
 ruby_binary = _binary

--- a/ruby/defs.bzl
+++ b/ruby/defs.bzl
@@ -1,32 +1,32 @@
 load(
-    "@bazelruby_rules_ruby//ruby/private:toolchain.bzl",
+    "@rules_ruby//ruby/private:toolchain.bzl",
     _toolchain = "ruby_toolchain",
 )
 load(
-    "@bazelruby_rules_ruby//ruby/private:library.bzl",
+    "@rules_ruby//ruby/private:library.bzl",
     _library = "ruby_library",
 )
 load(
-    "@bazelruby_rules_ruby//ruby/private:binary.bzl",
+    "@rules_ruby//ruby/private:binary.bzl",
     _binary = "ruby_binary",
     _test = "ruby_test",
 )
 load(
-    "@bazelruby_rules_ruby//ruby/private/bundle:def.bzl",
+    "@rules_ruby//ruby/private/bundle:def.bzl",
     _bundle = "bundle_install",
     _ruby_bundle = "ruby_bundle_install",
 )
 load(
-    "@bazelruby_rules_ruby//ruby/private:rspec.bzl",
+    "@rules_ruby//ruby/private:rspec.bzl",
     _rspec = "ruby_rspec",
     _rspec_test = "ruby_rspec_test",
 )
 load(
-    "@bazelruby_rules_ruby//ruby/private/rubocop:def.bzl",
+    "@rules_ruby//ruby/private/rubocop:def.bzl",
     _rubocop = "rubocop",
 )
 load(
-    "@bazelruby_rules_ruby//ruby/private/gemspec:def.bzl",
+    "@rules_ruby//ruby/private/gemspec:def.bzl",
     _gem = "gem",
     _gemspec = "gemspec",
 )

--- a/ruby/defs.bzl
+++ b/ruby/defs.bzl
@@ -7,6 +7,10 @@ load(
     _library = "ruby_library",
 )
 load(
+    "@rules_ruby//ruby/private:sdk.bzl",
+    _register_ruby_toolchain = "register_ruby_toolchain"
+)
+load(
     "@rules_ruby//ruby/private:binary.bzl",
     _binary = "ruby_binary",
     _test = "ruby_test",
@@ -31,6 +35,7 @@ load(
     _gemspec = "gemspec",
 )
 
+register_ruby_toolchain = _register_ruby_toolchain
 ruby_toolchain = _toolchain
 ruby_library = _library
 ruby_binary = _binary

--- a/ruby/deps.bzl
+++ b/ruby/deps.bzl
@@ -3,10 +3,5 @@ load(
     "@rules_ruby//ruby/private:dependencies.bzl",
     _rules_ruby_dependencies = "rules_ruby_dependencies",
 )
-load(
-    "@rules_ruby//ruby/private:sdk.bzl",
-    _rules_ruby_select_sdk = "rules_ruby_select_sdk",
-)
 
 rules_ruby_dependencies = _rules_ruby_dependencies
-rules_ruby_select_sdk = _rules_ruby_select_sdk

--- a/ruby/deps.bzl
+++ b/ruby/deps.bzl
@@ -1,10 +1,10 @@
 # Repository rules
 load(
-    "@bazelruby_rules_ruby//ruby/private:dependencies.bzl",
+    "@rules_ruby//ruby/private:dependencies.bzl",
     _rules_ruby_dependencies = "rules_ruby_dependencies",
 )
 load(
-    "@bazelruby_rules_ruby//ruby/private:sdk.bzl",
+    "@rules_ruby//ruby/private:sdk.bzl",
     _rules_ruby_select_sdk = "rules_ruby_select_sdk",
 )
 

--- a/ruby/deps.bzl
+++ b/ruby/deps.bzl
@@ -4,4 +4,10 @@ load(
     _rules_ruby_dependencies = "rules_ruby_dependencies",
 )
 
+load(
+    "@rules_ruby//ruby/private:sdk.bzl",
+    _rules_ruby_register_toolchains = "rules_ruby_register_toolchains",
+)
+
 rules_ruby_dependencies = _rules_ruby_dependencies
+rules_ruby_register_toolchains = _rules_ruby_register_toolchains

--- a/ruby/private/BUILD.bazel
+++ b/ruby/private/BUILD.bazel
@@ -1,6 +1,7 @@
 exports_files(
     [
         "binary_wrapper.tpl",
+        "binary_runner.tpl",
     ],
     visibility = ["//visibility:public"],
 )

--- a/ruby/private/binary.bzl
+++ b/ruby/private/binary.bzl
@@ -29,7 +29,9 @@ def _get_gem_path(incpaths):
 # to create a rule (eg, rubocop) that does exactly the same.
 def ruby_binary_macro(ctx, main, srcs):
     sdk = ctx.toolchains[TOOLCHAIN_TYPE_NAME].ruby_runtime
-    interpreter = sdk.interpreter[DefaultInfo].files_to_run.executable
+    interpreter_info = sdk.interpreter[DefaultInfo]
+    interpreter = interpreter_info.files_to_run.executable
+    interpreter_runfiles = interpreter_info.default_runfiles.merge(interpreter_info.data_runfiles)
 
     if not main:
         expected_name = "%s.rb" % ctx.attr.name
@@ -45,10 +47,11 @@ def ruby_binary_macro(ctx, main, srcs):
         )
 
     executable = ctx.actions.declare_file(ctx.attr.name)
+    wrapper = ctx.actions.declare_file(ctx.attr.name+"_wrapper")
 
     deps = _transitive_deps(
         ctx,
-        extra_files = [executable],
+        extra_files = [executable, wrapper, interpreter],
         extra_deps = ctx.attr._misc_deps,
     )
 
@@ -60,21 +63,35 @@ def ruby_binary_macro(ctx, main, srcs):
 
     ctx.actions.expand_template(
         template = ctx.file._wrapper_template,
-        output = executable,
+        output = wrapper,
         substitutions = {
             "{loadpaths}": repr(deps.incpaths.to_list()),
             "{rubyopt}": repr(rubyopt),
             "{main}": repr(_to_manifest_path(ctx, main)),
-            "{interpreter}": _to_manifest_path(ctx, interpreter),
             "{gem_path}": gem_path,
             "{should_gem_pristine}": str(len(gems_to_pristine) > 0).lower(),
             "{gems_to_pristine}": " ".join(gems_to_pristine),
         },
     )
+    
+    ctx.actions.expand_template(
+        template = ctx.file._runner_template,
+        output = executable,
+        substitutions = {
+            "{main}": wrapper.short_path,
+            "{interpreter}": interpreter.short_path,
+            "{workspace_name}": ctx.label.workspace_name or ctx.workspace_name,
+        },
+        is_executable = True,
+    )
 
     info = DefaultInfo(
         executable = executable,
-        runfiles = deps.default_files.merge(deps.data_files),
+        runfiles = deps.default_files.merge_all([
+            deps.data_files,
+            interpreter_runfiles,
+            ctx.runfiles(files = [wrapper]),
+        ]),
     )
 
     return [info]

--- a/ruby/private/binary_runner.tpl
+++ b/ruby/private/binary_runner.tpl
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ -n "${RUNFILES_DIR+x}" ]; then
+  PATH_PREFIX=$RUNFILES_DIR/{workspace_name}/
+elif [ -s `dirname $0`/../../MANIFEST ]; then
+  PATH_PREFIX=`cd $(dirname $0); pwd`/
+elif [ -d $0.runfiles ]; then
+  PATH_PREFIX=`cd $0.runfiles; pwd`/{workspace_name}/
+else
+  echo "WARNING: it does not look to be at the .runfiles directory" >&2
+  exit 1
+fi
+
+$PATH_PREFIX{interpreter} -I${PATH_PREFIX} ${PATH_PREFIX}{main} "$@"

--- a/ruby/private/binary_wrapper.tpl
+++ b/ruby/private/binary_wrapper.tpl
@@ -1,5 +1,3 @@
-#!/usr/bin/env ruby
-
 # Ruby-port of the Bazel's wrapper script for Python
 
 # Copyright 2017 The Bazel Authors. All rights reserved.

--- a/ruby/private/constants.bzl
+++ b/ruby/private/constants.bzl
@@ -71,7 +71,7 @@ RSPEC_ATTRS.update(_RSPEC_ATTRS)
 
 BUNDLE_ATTRS = {
     "ruby_interpreter": attr.label(
-        default = "//external:rules_ruby_system_interpreter",
+        default = "@local_config_ruby_system//:ruby",
     ),
     "gemfile": attr.label(
         allow_single_file = True,

--- a/ruby/private/constants.bzl
+++ b/ruby/private/constants.bzl
@@ -71,7 +71,7 @@ RSPEC_ATTRS.update(_RSPEC_ATTRS)
 
 BUNDLE_ATTRS = {
     "ruby_interpreter": attr.label(
-        default = "@rules_ruby_default_toolchain//:ruby",
+        default = "//external:rules_ruby_system_interpreter",
     ),
     "gemfile": attr.label(
         allow_single_file = True,
@@ -155,3 +155,15 @@ GEMSPEC_ATTRS = {
         default = "%s//ruby/private/gemspec:readme_template.tpl" % RULES_RUBY_WORKSPACE_NAME,
     ),
 }
+
+SUPPORTED_VERSIONS = [
+    "system",
+    "2.5.8",
+    "2.6.8",
+    "2.7.5",
+    "3.0.3",
+    "3.1.1",
+    "jruby-9.2.21.0", # Corresponded to 2.5.8
+    "jruby-9.3.6.0", # Corresponds to 2.6.8
+]
+

--- a/ruby/private/constants.bzl
+++ b/ruby/private/constants.bzl
@@ -70,11 +70,8 @@ RSPEC_ATTRS.update(RUBY_ATTRS)
 RSPEC_ATTRS.update(_RSPEC_ATTRS)
 
 BUNDLE_ATTRS = {
-    "ruby_sdk": attr.string(
-        default = "@org_ruby_lang_ruby_toolchain",
-    ),
     "ruby_interpreter": attr.label(
-        default = "@org_ruby_lang_ruby_toolchain//:ruby",
+        default = "@rules_ruby_default_toolchain//:ruby",
     ),
     "gemfile": attr.label(
         allow_single_file = True,

--- a/ruby/private/constants.bzl
+++ b/ruby/private/constants.bzl
@@ -38,6 +38,10 @@ RUBY_ATTRS = {
         allow_single_file = True,
         default = "binary_wrapper.tpl",
     ),
+    "_runner_template": attr.label(
+        allow_single_file = True,
+        default = "binary_runner.tpl",
+    ),
     "_misc_deps": attr.label_list(
         allow_files = True,
         default = ["@bazel_tools//tools/bash/runfiles"],

--- a/ruby/private/constants.bzl
+++ b/ruby/private/constants.bzl
@@ -1,7 +1,7 @@
 # Ruby Constants
 load(":providers.bzl", "RubyLibraryInfo")
 
-RULES_RUBY_WORKSPACE_NAME = "@bazelruby_rules_ruby"
+RULES_RUBY_WORKSPACE_NAME = "@rules_ruby"
 TOOLCHAIN_TYPE_NAME = "%s//ruby:toolchain_type" % RULES_RUBY_WORKSPACE_NAME
 
 DEFAULT_BUNDLER_VERSION = "2.1.4"

--- a/ruby/private/providers.bzl
+++ b/ruby/private/providers.bzl
@@ -19,6 +19,17 @@ RubyRuntimeInfo = provider(
     ],
 )
 
+RubyRuntimeToolchainInfo = provider(
+    doc = "Information about a Ruby interpreter, related commands and libraries",
+    fields = {
+        "interpreter": "A label which points the Ruby interpreter",
+        "bundler": "A label which points bundler command",
+        "runtime": "A list of labels which points runtime libraries",
+        "headers": "A list of labels which points to the ruby headers",
+        "rubyopt": "A list of strings which should be passed to the interpreter as command line options",
+    },
+)
+
 RubyGemInfo = provider(
     doc = "Carries info required to package a ruby gem",
     fields = [

--- a/ruby/private/rubocop/def.bzl
+++ b/ruby/private/rubocop/def.bzl
@@ -1,4 +1,4 @@
-load("@bazelruby_rules_ruby//ruby/private:binary.bzl", "ruby_binary")
+load("@rules_ruby//ruby/private:binary.bzl", "ruby_binary")
 
 # This wraps an rb_binary in a script that is executed from the workspace folder
 def rubocop(name, bin, deps):
@@ -9,7 +9,7 @@ def rubocop(name, bin, deps):
         deps = deps,
     )
 
-    runner = "@bazelruby_rules_ruby//ruby/private/rubocop:runner.sh.tpl"
+    runner = "@rules_ruby//ruby/private/rubocop:runner.sh.tpl"
     native.genrule(
         name = name,
         tools = [bin_name],

--- a/ruby/private/runtime_alias.bzl
+++ b/ruby/private/runtime_alias.bzl
@@ -1,0 +1,40 @@
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load(":constants.bzl", "TOOLCHAIN_TYPE_NAME")
+load(":providers.bzl", "RubyRuntimeToolchainInfo")
+
+# These rules expose the runtime targets of whichever toolchain has been resolved.
+
+def _ruby_runtime_alias_impl(ctx):
+    ruby = ctx.toolchains[TOOLCHAIN_TYPE_NAME].ruby_runtime
+    return [
+        DefaultInfo(
+            runfiles = ctx.runfiles(transitive_files = depset(ruby.runtime)),
+            files = depset(ruby.runtime),
+        ),
+        ruby,
+    ]
+
+ruby_runtime_alias = rule(
+    implementation = _ruby_runtime_alias_impl,
+    toolchains = [TOOLCHAIN_TYPE_NAME],
+)
+
+def _ruby_headers_alias_impl(ctx):
+    runtime = ctx.attr.runtime[RubyRuntimeToolchainInfo]
+    target = runtime.headers
+    return [
+        ctx.attr.runtime[DefaultInfo],
+        target[CcInfo],
+        target[InstrumentedFilesInfo],
+        target[OutputGroupInfo],
+    ]
+
+ruby_headers_alias = rule(
+    implementation = _ruby_headers_alias_impl,
+    attrs = {
+        "runtime": attr.label(
+            doc = "The runtime alias to use.",
+            mandatory = True,
+        ),
+    },
+)

--- a/ruby/private/sdk.bzl
+++ b/ruby/private/sdk.bzl
@@ -3,11 +3,11 @@ load(
     _ruby_runtime = "ruby_runtime",
 )
 
-def rules_ruby_select_sdk(version = "host"):
+def register_ruby_toolchain(name, version = "system"):
     """Registers ruby toolchains in the WORKSPACE file."""
 
     supported_versions = [
-        "host",
+        "system",
         "2.5.8",
         "2.5.9",
         "2.6.3",
@@ -38,13 +38,21 @@ def rules_ruby_select_sdk(version = "host"):
             break
 
     if not supported_version:
-        fail("rules_ruby_select_sdk: unsupported ruby version '%s' not in '%s'" % (version, supported_versions))
+        fail("register_ruby_toolchain: unsupported ruby version '%s' not in '%s'" % (version, supported_versions))
 
     _ruby_runtime(
-        name = "org_ruby_lang_ruby_toolchain",
+        name = name,
+        version = supported_version,
+    )
+
+    _ruby_runtime(
+        name = "rules_ruby_default_toolchain",
         version = supported_version,
     )
 
     native.register_toolchains(
-        "@org_ruby_lang_ruby_toolchain//:toolchain",
+        "@%s//:toolchain" % name,
+    )
+    native.register_toolchains(
+        "@rules_ruby_default_toolchain//:toolchain",
     )

--- a/ruby/private/sdk.bzl
+++ b/ruby/private/sdk.bzl
@@ -1,58 +1,33 @@
-load(
-    "@rules_ruby//ruby/private/toolchains:ruby_runtime.bzl",
-    _ruby_runtime = "ruby_runtime",
-)
+load("@rules_ruby//ruby/private/toolchains:ruby_runtime.bzl", "ruby_runtime")
+load (":constants.bzl", "SUPPORTED_VERSIONS")
 
 def register_ruby_toolchain(name, version = "system"):
     """Registers ruby toolchains in the WORKSPACE file."""
 
-    supported_versions = [
-        "system",
-        "2.5.8",
-        "2.5.9",
-        "2.6.3",
-        "2.6.4",
-        "2.6.5",
-        "2.6.6",
-        "2.6.7",
-        "2.6.8",
-        "2.6.9",
-        "2.7.1",
-        "2.7.2",
-        "2.7.3",
-        "2.7.4",
-        "2.7.5",
-        "3.0.0",
-        "3.0.1",
-        "3.0.2",
-        "3.0.3",
-        "3.1.0",
-        "3.1.1",
-        "jruby-9.2.21.0",
-        "jruby-9.3.6.0",
-    ]
-
-    for v in sorted(supported_versions, reverse=True):
+    for v in sorted(SUPPORTED_VERSIONS, reverse=True):
         if v.startswith(version):
             supported_version = v
             break
 
     if not supported_version:
-        fail("register_ruby_toolchain: unsupported ruby version '%s' not in '%s'" % (version, supported_versions))
+        fail("register_ruby_toolchain: unsupported ruby version '%s' not in '%s'" % (version, SUPPORTED_VERSIONS))
 
-    _ruby_runtime(
+    ruby_runtime(
         name = name,
-        version = supported_version,
-    )
-
-    _ruby_runtime(
-        name = "rules_ruby_default_toolchain",
         version = supported_version,
     )
 
     native.register_toolchains(
         "@%s//:toolchain" % name,
     )
-    native.register_toolchains(
-        "@rules_ruby_default_toolchain//:toolchain",
-    )
+
+    # Bind the system ruby rules that we need internally.
+    if version == "system":
+        native.bind(
+            name = "rules_ruby_system_jruby_implementation",
+            actual = "@%s//:jruby_implementation" % name
+        )
+        native.bind(
+            name = "rules_ruby_system_interpreter",
+            actual = "@%s//:ruby" % name
+        )

--- a/ruby/private/sdk.bzl
+++ b/ruby/private/sdk.bzl
@@ -1,5 +1,5 @@
 load(
-    "@bazelruby_rules_ruby//ruby/private/toolchains:ruby_runtime.bzl",
+    "@rules_ruby//ruby/private/toolchains:ruby_runtime.bzl",
     _ruby_runtime = "ruby_runtime",
 )
 

--- a/ruby/private/sdk.bzl
+++ b/ruby/private/sdk.bzl
@@ -1,16 +1,19 @@
 load("@rules_ruby//ruby/private/toolchains:ruby_runtime.bzl", "ruby_runtime")
 load (":constants.bzl", "SUPPORTED_VERSIONS")
 
-def register_ruby_toolchain(name, version = "system"):
+def _register_toolchain(version):
     """Registers ruby toolchains in the WORKSPACE file."""
+    name = "local_config_ruby_%s" % version
+    supported_version = None
 
+    version = version.removeprefix("ruby-")
     for v in sorted(SUPPORTED_VERSIONS, reverse=True):
         if v.startswith(version):
             supported_version = v
             break
 
     if not supported_version:
-        fail("register_ruby_toolchain: unsupported ruby version '%s' not in '%s'" % (version, SUPPORTED_VERSIONS))
+        fail("rules_ruby_register_toolchains: unsupported ruby version '%s' not in '%s'" % (version, SUPPORTED_VERSIONS))
 
     ruby_runtime(
         name = name,
@@ -21,13 +24,25 @@ def register_ruby_toolchain(name, version = "system"):
         "@%s//:toolchain" % name,
     )
 
-    # Bind the system ruby rules that we need internally.
-    if version == "system":
-        native.bind(
-            name = "rules_ruby_system_jruby_implementation",
-            actual = "@%s//:jruby_implementation" % name
-        )
-        native.bind(
-            name = "rules_ruby_system_interpreter",
-            actual = "@%s//:ruby" % name
-        )
+def rules_ruby_register_toolchains(version = None):
+    _register_toolchain("system")
+    if version != "system":
+        if version:
+            _register_toolchain(version)
+        else:
+            _register_toolchain("2.5")
+            _register_toolchain("2.6")
+            _register_toolchain("2.7")
+            _register_toolchain("3.0")
+            _register_toolchain("3.1")
+            _register_toolchain("jruby-9.2")
+            _register_toolchain("jruby-9.3")
+
+    native.bind(
+        name = "rules_ruby_system_jruby_implementation",
+        actual = "@local_config_ruby_system//:jruby_implementation"
+    )
+    native.bind(
+        name = "rules_ruby_system_interpreter",
+        actual = "@local_config_ruby_system//:ruby"
+    )

--- a/ruby/private/sdk.bzl
+++ b/ruby/private/sdk.bzl
@@ -28,15 +28,22 @@ def rules_ruby_select_sdk(version = "host"):
         "3.0.3",
         "3.1.0",
         "3.1.1",
+        "jruby-9.2.21.0",
+        "jruby-9.3.6.0",
     ]
 
-    if version in supported_versions:
-        _ruby_runtime(
-            name = "org_ruby_lang_ruby_toolchain",
-            version = version,
-        )
-    else:
+    for v in sorted(supported_versions, reverse=True):
+        if v.startswith(version):
+            supported_version = v
+            break
+
+    if not supported_version:
         fail("rules_ruby_select_sdk: unsupported ruby version '%s' not in '%s'" % (version, supported_versions))
+
+    _ruby_runtime(
+        name = "org_ruby_lang_ruby_toolchain",
+        version = supported_version,
+    )
 
     native.register_toolchains(
         "@org_ruby_lang_ruby_toolchain//:toolchain",

--- a/ruby/private/toolchain.bzl
+++ b/ruby/private/toolchain.bzl
@@ -1,21 +1,13 @@
 load(":constants.bzl", "RULES_RUBY_WORKSPACE_NAME")
-
-RubyRuntimeInfo = provider(
-    doc = "Information about a Ruby interpreter, related commands and libraries",
-    fields = {
-        "interpreter": "A label which points the Ruby interpreter",
-        "bundler": "A label which points bundler command",
-        "runtime": "A list of labels which points runtime libraries",
-        "rubyopt": "A list of strings which should be passed to the interpreter as command line options",
-    },
-)
+load(":providers.bzl", "RubyRuntimeToolchainInfo")
 
 def _ruby_toolchain_impl(ctx):
     return [
         platform_common.ToolchainInfo(
-            ruby_runtime = RubyRuntimeInfo(
+            ruby_runtime = RubyRuntimeToolchainInfo(
                 interpreter = ctx.attr.interpreter,
                 runtime = ctx.files.runtime,
+                headers = ctx.attr.headers,
                 rubyopt = ctx.attr.rubyopt,
             ),
         ),
@@ -35,6 +27,11 @@ _ruby_toolchain = rule(
             allow_files = True,
             cfg = "target",
         ),
+        "headers": attr.label(
+            mandatory = True,
+            allow_files = True,
+            cfg = "target",
+        ),
         "rubyopt": attr.string_list(
             default = [],
         ),
@@ -45,6 +42,7 @@ def ruby_toolchain(
         name,
         interpreter,
         runtime,
+        headers,
         rubyopt = [],
         rules_ruby_workspace = RULES_RUBY_WORKSPACE_NAME,
         **kwargs):
@@ -53,6 +51,7 @@ def ruby_toolchain(
         name = impl_name,
         interpreter = interpreter,
         runtime = runtime,
+        headers = headers,
         rubyopt = rubyopt,
     )
 

--- a/ruby/private/toolchains/BUILD.runtime.tpl
+++ b/ruby/private/toolchains/BUILD.runtime.tpl
@@ -12,6 +12,10 @@ ruby_toolchain(
     interpreter = "//:ruby_bin",
     rules_ruby_workspace = "{rules_ruby_workspace}",
     runtime = "//:runtime",
+    headers = "//:headers",
+    target_settings = [
+        "{rules_ruby_workspace}//ruby/runtime:{setting}"
+    ],
     # TODO(yugui) Extract platform info from RbConfig
     # exec_compatible_with = [],
     # target_compatible_with = [],
@@ -51,8 +55,8 @@ filegroup(
 # This should never be overridden, and is determined automatically during the
 # creation of the toolchain.
 string_flag(
-    name = "internal_ruby_platform",
-    build_setting_default = "{platform}",
+    name = "internal_ruby_implementation",
+    build_setting_default = "{implementation}",
     values = [
         "ruby",
         "jruby",
@@ -60,16 +64,16 @@ string_flag(
 )
 
 config_setting(
-    name = "platform_jruby",
+    name = "jruby_implementation",
     flag_values = {
-        ":internal_ruby_platform": "jruby",
+        ":internal_ruby_implementation": "jruby",
     },
 )
 
 config_setting(
-    name = "platform_ruby",
+    name = "ruby_implementation",
     flag_values = {
-        ":internal_ruby_platform": "ruby",
+        ":internal_ruby_implementation": "ruby",
     },
 )
 

--- a/ruby/private/toolchains/BUILD.runtime.tpl
+++ b/ruby/private/toolchains/BUILD.runtime.tpl
@@ -3,6 +3,7 @@ load(
     "ruby_library",
     "ruby_toolchain",
 )
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -44,6 +45,32 @@ filegroup(
             "WORKSPACE",
         ],
     ),
+)
+
+# Provide config settings to signal the ruby platform to downstream code.
+# This should never be overridden, and is determined automatically during the
+# creation of the toolchain.
+string_flag(
+    name = "internal_ruby_platform",
+    build_setting_default = "{platform}",
+    values = [
+        "ruby",
+        "jruby",
+    ],
+)
+
+config_setting(
+    name = "platform_jruby",
+    flag_values = {
+        ":internal_ruby_platform": "jruby",
+    },
+)
+
+config_setting(
+    name = "platform_ruby",
+    flag_values = {
+        ":internal_ruby_platform": "ruby",
+    },
 )
 
 # vim: set ft=bzl :

--- a/ruby/private/toolchains/ruby_runtime.bzl
+++ b/ruby/private/toolchains/ruby_runtime.bzl
@@ -101,6 +101,17 @@ def _install_ruby(ctx, ruby):
         shared_library = _relativate(shared_library),
     )
 
+def get_ruby_info(ctx, interpreter_path):
+    platform = ctx.execute([interpreter_path, "-e", "print RUBY_PLATFORM"]).stdout
+    if platform == "java":
+        ruby_impl = "jruby"
+        ruby_version = ctx.execute([interpreter_path, "-e", "print JRUBY_VERSION"]).stdout
+    else:
+        ruby_impl = "ruby"
+        ruby_version = ctx.execute([interpreter_path, "-e", "print RUBY_VERSION"]).stdout
+
+    return ruby_impl, ruby_version
+
 def system_ruby_is_correct_version(ctx, version):
     interpreter_path = ctx.which("ruby")
 
@@ -108,9 +119,8 @@ def system_ruby_is_correct_version(ctx, version):
         print("Can't find ruby interpreter in the PATH")
         return False
 
-    ruby_version = ctx.execute(["ruby", "-e", "print RUBY_VERSION"]).stdout
-    ruby_platform = ctx.execute(["ruby", "-e", "print RUBY_PLATFORM"]).stdout
-    if ruby_platform == "java":
+    ruby_impl, ruby_version = get_ruby_info(ctx, interpreter_path)
+    if ruby_impl == "jruby":
         ruby_version = "jruby-" + ruby_version
 
     have_ruby_version = (version == ruby_version)
@@ -139,11 +149,7 @@ def _ruby_runtime_impl(ctx):
 
     installed = _install_ruby(ctx, ruby)
 
-    ruby_platform = ctx.execute(["ruby", "-e", "print RUBY_PLATFORM"]).stdout
-    if ruby_platform == "java":
-        ruby_platform = "jruby"
-    else:
-        ruby_platform = "ruby"
+    ruby_impl, ruby_version = get_ruby_info(ctx, interpreter_path)
 
     ctx.template(
         "BUILD.bazel",
@@ -154,7 +160,9 @@ def _ruby_runtime_impl(ctx):
             "{static_library}": repr(installed.static_library),
             "{shared_library}": repr(installed.shared_library),
             "{rules_ruby_workspace}": RULES_RUBY_WORKSPACE_NAME,
-            "{platform}": ruby_platform,
+            "{implementation}": ruby_impl,
+            "{version}": ruby_version,
+            "{setting}": "config_system" if version == "system" else "config_%s-%s" % (ruby_impl, ruby_version),
         },
         executable = False,
     )

--- a/ruby/runtime/BUILD.bazel
+++ b/ruby/runtime/BUILD.bazel
@@ -1,0 +1,151 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@rules_ruby//ruby/private:runtime_alias.bzl",
+    _ruby_headers_alias = "ruby_headers_alias",
+    _ruby_runtime_alias = "ruby_runtime_alias",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+toolchain_type(name = "toolchain_type")
+
+# Alias targets corresponding to whichever toolchain was resolved based on
+# the selected version.
+
+_ruby_runtime_alias(
+    name = "runtime",
+)
+
+_ruby_headers_alias(
+    name = "headers",
+    runtime = ":runtime",
+)
+
+# Supported ruby versions, which can be selected by flags.
+# For example: --@rules_ruby//ruby/runtime:version=jruby-9.3
+string_flag(
+    name = "version",
+    build_setting_default = "system",
+    values = [
+        "system",
+        "ruby-2.5",
+        "ruby-2.6",
+        "ruby-2.7",
+        "ruby-3.0",
+        "ruby-3.1",
+        "jruby-9.2",
+        "jruby-9.3",
+    ],
+)
+
+config_setting(
+    name = "config_system",
+    flag_values = { "version" : "system" },
+)
+
+config_setting(
+    name = "config_ruby-2.5.8",
+    flag_values = { "version" : "ruby-2.5" },
+)
+
+alias(
+    name = "config_ruby_25",
+    actual = ":config_ruby-2.5.8"
+)
+
+config_setting(
+    name = "config_ruby-2.6.8",
+    flag_values = { "version" : "ruby-2.6" },
+)
+
+alias(
+    name = "config_ruby_26",
+    actual = ":config_ruby-2.6.8"
+)
+
+config_setting(
+    name = "config_ruby-2.7.5",
+    flag_values = { "version" : "ruby-2.7" },
+)
+
+alias(
+    name = "config_ruby_27",
+    actual = ":config_ruby-2.7.5"
+)
+
+config_setting(
+    name = "config_ruby-3.0.3",
+    flag_values = { "version" : "ruby-3.0" },
+)
+
+alias(
+    name = "config_ruby_30",
+    actual = ":config_ruby-3.0.3"
+)
+
+config_setting(
+    name = "config_ruby-3.1.1",
+    flag_values = { "version" : "ruby-3.1" },
+)
+
+alias(
+    name = "config_ruby_31",
+    actual = ":config_ruby-3.1.1"
+)
+
+selects.config_setting_group(
+    name = "config_system_ruby",
+    match_all = [
+        ":config_system",
+        "//external:rules_ruby_system_jruby_implementation",
+    ],
+)
+
+selects.config_setting_group(
+    name = "config_ruby",
+    match_any = [
+        ":config_system_ruby",
+        ":config_ruby_25",
+        ":config_ruby_26",
+        ":config_ruby_27",
+        ":config_ruby_30",
+        ":config_ruby_31",
+    ],
+)
+
+config_setting(
+    name = "config_jruby-9.2.21.0",
+    flag_values = { "version" : "jruby-9.2" },
+)
+
+alias(
+    name = "config_jruby_92",
+    actual = ":config_jruby-9.2.21.0"
+)
+
+config_setting(
+    name = "config_jruby-9.3.6.0",
+    flag_values = { "version" : "jruby-9.3" },
+)
+
+alias(
+    name = "config_jruby_93",
+    actual = ":config_jruby-9.3.6.0"
+)
+
+selects.config_setting_group(
+    name = "config_system_jruby",
+    match_all = [
+        ":config_system",
+        "//external:rules_ruby_system_jruby_implementation",
+    ],
+)
+
+selects.config_setting_group(
+    name = "config_jruby",
+    match_any = [
+        ":config_system_jruby",
+        ":config_jruby_92",
+        ":config_jruby_93",
+    ],
+)

--- a/ruby/tests/BUILD.bazel
+++ b/ruby/tests/BUILD.bazel
@@ -65,7 +65,7 @@ sh_test(
     ],
     data = [
         "args_check.rb",
-        "@org_ruby_lang_ruby_toolchain//:ruby_bin",
+        "@ruby-system//:ruby_bin",
     ],
 )
 
@@ -74,7 +74,7 @@ genrule(
     name = "generate_genrule_run_ruby_test",
     outs = ["genrules_run_ruby_test.sh"],
     cmd = " && ".join([
-        ("$(location @org_ruby_lang_ruby_toolchain//:ruby_bin) " +
+        ("$(location @ruby-system//:ruby_bin) " +
          "$(location args_check.rb) foo bar baz"),
         "echo '#!/bin/sh -e' > $@",
         "echo true >> $@",
@@ -83,8 +83,8 @@ genrule(
     output_to_bindir = 1,
     tools = [
         "args_check.rb",
-        "@org_ruby_lang_ruby_toolchain//:ruby_bin",
-        "@org_ruby_lang_ruby_toolchain//:runtime",
+        "@ruby-system//:ruby_bin",
+        "@ruby-system//:runtime",
     ],
 )
 
@@ -188,7 +188,7 @@ cc_binary(
     testonly = True,
     srcs = ["example_ext.c"],
     linkshared = True,
-    deps = ["@org_ruby_lang_ruby_toolchain//:headers"],
+    deps = ["@ruby-system//:headers"],
 )
 
 cc_library(
@@ -197,7 +197,7 @@ cc_library(
     srcs = ["example_ext.c"],
     linkstatic = True,
     tags = ["manual"],
-    deps = ["@org_ruby_lang_ruby_toolchain//:headers"],
+    deps = ["@ruby-system//:headers"],
     alwayslink = True,
 )
 

--- a/ruby/tests/BUILD.bazel
+++ b/ruby/tests/BUILD.bazel
@@ -120,7 +120,7 @@ ruby_binary(
     main = "load_path_in_runfiles_test.rb",
     deps = [
         "//ruby/tests/testdata:g",
-        "@bazelruby_rules_ruby_ruby_tests_testdata_another_workspace//baz/qux:j",
+        "@rules_ruby_ruby_tests_testdata_another_workspace//baz/qux:j",
     ],
 )
 
@@ -137,7 +137,7 @@ ruby_test(
     main = "load_path_in_runfiles_test.rb",
     deps = [
         "//ruby/tests/testdata:g",
-        "@bazelruby_rules_ruby_ruby_tests_testdata_another_workspace//baz/qux:j",
+        "@rules_ruby_ruby_tests_testdata_another_workspace//baz/qux:j",
     ],
 )
 
@@ -250,13 +250,13 @@ pkg_tar(
     include_runfiles = True,
     package_dir = "/app",
     remap_paths = {
-        "ruby": "load_path_in_runfiles.runfiles/bazelruby_rules_ruby/ruby",
+        "ruby": "load_path_in_runfiles.runfiles/rules_ruby/ruby",
         ".": "load_path_in_runfiles.runfiles/",
     },
     strip_prefix = "dummy",
     symlinks = {
-        "/app/load_path_in_runfiles.runfiles/bazelruby_rules_ruby/external": "/app/load_path_in_runfiles.runfiles",
-        "/app/load_path_in_runfiles": "/app/load_path_in_runfiles.runfiles/bazelruby_rules_ruby/ruby/tests/load_path_in_runfiles",
+        "/app/load_path_in_runfiles.runfiles/rules_ruby/external": "/app/load_path_in_runfiles.runfiles",
+        "/app/load_path_in_runfiles": "/app/load_path_in_runfiles.runfiles/rules_ruby/ruby/tests/load_path_in_runfiles",
     },
 )
 

--- a/ruby/tests/load_path_in_runfiles_test.rb
+++ b/ruby/tests/load_path_in_runfiles_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 require 'ruby/tests/testdata/foo/g'
-require 'external/bazelruby_rules_ruby_ruby_tests_testdata_another_workspace/baz/qux/j'
+require 'external/rules_ruby_ruby_tests_testdata_another_workspace/baz/qux/j'
 
 [g, j]

--- a/ruby/tests/runtime_run_ruby_test.sh
+++ b/ruby/tests/runtime_run_ruby_test.sh
@@ -1,2 +1,2 @@
 #!/bin/sh -e
-external/org_ruby_lang_ruby_toolchain/ruby_bin $*
+external/ruby-system/ruby_bin $*

--- a/ruby/tests/testdata/another_workspace/WORKSPACE
+++ b/ruby/tests/testdata/another_workspace/WORKSPACE
@@ -1,5 +1,5 @@
 workspace(name = "rules_ruby_ruby_tests_testdata_another_workspace")
 
-load("@rules_ruby//ruby:defs.bzl", "rules_ruby_select_sdk")
+load("@rules_ruby//ruby:defs.bzl", "register_ruby_toolchain")
 
-rules_ruby_select_sdk()
+register_ruby_toolchain(name = "ruby")

--- a/ruby/tests/testdata/another_workspace/WORKSPACE
+++ b/ruby/tests/testdata/another_workspace/WORKSPACE
@@ -1,5 +1,5 @@
-workspace(name = "bazelruby_rules_ruby_ruby_tests_testdata_another_workspace")
+workspace(name = "rules_ruby_ruby_tests_testdata_another_workspace")
 
-load("@bazelruby_rules_ruby//ruby:defs.bzl", "rules_ruby_select_sdk")
+load("@rules_ruby//ruby:defs.bzl", "rules_ruby_select_sdk")
 
 rules_ruby_select_sdk()

--- a/ruby/tests/testdata/another_workspace/WORKSPACE
+++ b/ruby/tests/testdata/another_workspace/WORKSPACE
@@ -1,5 +1,4 @@
 workspace(name = "rules_ruby_ruby_tests_testdata_another_workspace")
 
-load("@rules_ruby//ruby:defs.bzl", "register_ruby_toolchain")
-
-register_ruby_toolchain(name = "ruby")
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
+rules_ruby_register_toolchains("system")

--- a/ruby/tests/testdata/another_workspace/baz/qux/BUILD.bazel
+++ b/ruby/tests/testdata/another_workspace/baz/qux/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazelruby_rules_ruby//ruby:defs.bzl", "ruby_library")
+load("@rules_ruby//ruby:defs.bzl", "ruby_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/ruby/tests/testdata/bundle_includes_workspace/BUILD.bazel
+++ b/ruby/tests/testdata/bundle_includes_workspace/BUILD.bazel
@@ -1,5 +1,5 @@
 load(
-    "@bazelruby_rules_ruby//ruby:defs.bzl",
+    "@rules_ruby//ruby:defs.bzl",
     "ruby_binary",
 )
 

--- a/ruby/tests/testdata/bundle_includes_workspace/WORKSPACE
+++ b/ruby/tests/testdata/bundle_includes_workspace/WORKSPACE
@@ -1,12 +1,12 @@
-workspace(name = "bazelruby_rules_ruby_ruby_tests_testdata_bundle_includes_workspace")
+workspace(name = "rules_ruby_ruby_tests_testdata_bundle_includes_workspace")
 
 local_repository(
-    name = "bazelruby_rules_ruby",
+    name = "rules_ruby",
     path = "../../../..",
 )
 
 load(
-    "@bazelruby_rules_ruby//ruby:deps.bzl",
+    "@rules_ruby//ruby:deps.bzl",
     "rules_ruby_dependencies",
     "rules_ruby_select_sdk",
 )
@@ -15,7 +15,7 @@ rules_ruby_dependencies()
 
 rules_ruby_select_sdk(version = "3.0.2")
 
-load("@bazelruby_rules_ruby//ruby:defs.bzl", "ruby_bundle")
+load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "gems",

--- a/ruby/tests/testdata/bundle_includes_workspace/WORKSPACE
+++ b/ruby/tests/testdata/bundle_includes_workspace/WORKSPACE
@@ -5,12 +5,12 @@ local_repository(
     path = "../../../..",
 )
 
-load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies", "rules_ruby_register_toolchains")
+
 rules_ruby_dependencies()
+rules_ruby_register_toolchains("3.0.2")
 
-load("@rules_ruby//ruby:defs.bzl", "register_ruby_toolchain", "ruby_bundle")
-
-register_ruby_toolchain(name = "ruby-3.0", version = "3.0.2")
+load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "gems",

--- a/ruby/tests/testdata/bundle_includes_workspace/WORKSPACE
+++ b/ruby/tests/testdata/bundle_includes_workspace/WORKSPACE
@@ -5,17 +5,12 @@ local_repository(
     path = "../../../..",
 )
 
-load(
-    "@rules_ruby//ruby:deps.bzl",
-    "rules_ruby_dependencies",
-    "rules_ruby_select_sdk",
-)
-
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 rules_ruby_dependencies()
 
-rules_ruby_select_sdk(version = "3.0.2")
+load("@rules_ruby//ruby:defs.bzl", "register_ruby_toolchain", "ruby_bundle")
 
-load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
+register_ruby_toolchain(name = "ruby-3.0", version = "3.0.2")
 
 ruby_bundle(
     name = "gems",


### PR DESCRIPTION
This adds more useable versioning support to rules_ruby.

Downstream projects should `call rules_ruby_register_toolchains` which will setup the allowed ruby toolchains for each version, including the system installation.  The `--@rules_ruby//ruby:version=<version>` flag can be passed to switch between these dynamically, with the default being whatever is currently installed on the system.

`ruby_binary` will use the interpreter from whichever toolchain was resolved.  Downstream targets can access information about the selected installation via the following targets:

- @rules_ruby//ruby/runtime:headers - The c headers exported by the runtime
- @rules_ruby//ruby/runtime:config_jruby - A setting that specifies that this is a Java implementation of ruby (jruby)
- @rules_ruby//ruby/runtime:config_ruby - A setting that specifies that this is a standard C implementation of ruby