### PR TITLE
Handle absolute extension paths 

### DIFF
--- a/ruby/private/binary.bzl
+++ b/ruby/private/binary.bzl
@@ -12,22 +12,15 @@ def _to_manifest_path(ctx, file):
 
 def _get_gem_path(incpaths):
     """
-    incpaths is a list of
-    `<bundle_name>/lib/ruby/<version>/gems/<gemname>-<gemversion>/lib` or
-    `<bundle_name>/lib/ruby/<version>/bundler/gems/<gemname>-<githash>/lib` or
-    `<bundle_name>/lib/ruby/<version>/extensions/<archetecture>-<platform>/<version>/<gemname>-<gemversion>` or
-    any other ruby dependency
+    incpaths is a list of `<bundle_name>/lib/ruby/<version>/gems/<gemname>-<gemversion>/lib`
     The gem_path is `<bundle_name>/lib/ruby/<version>` so we can go from an incpath to the
     gem_path pretty easily without much additional work.
     """
     if len(incpaths) == 0:
         return ""
-    for incpath in incpaths:
-        print(incpath)
-        parts = incpath.split('/', 4)
-        if len(parts) == 5 and parts[1] == 'lib' and parts[2] == 'ruby':
-            return '/'.join(parts[:4])
-    return ""
+    incpath = incpaths[0]
+    return incpath.rsplit("/", 3)[0]
+
 # Having this function allows us to override otherwise frozen attributes
 # such as main, srcs and deps. We use this in ruby_rspec_test rule by
 # adding rspec as a main, and sources, and rspec gem as a dependency.

--- a/ruby/private/binary.bzl
+++ b/ruby/private/binary.bzl
@@ -12,15 +12,22 @@ def _to_manifest_path(ctx, file):
 
 def _get_gem_path(incpaths):
     """
-    incpaths is a list of `<bundle_name>/lib/ruby/<version>/gems/<gemname>-<gemversion>/lib`
+    incpaths is a list of
+    `<bundle_name>/lib/ruby/<version>/gems/<gemname>-<gemversion>/lib` or
+    `<bundle_name>/lib/ruby/<version>/bundler/gems/<gemname>-<githash>/lib` or
+    `<bundle_name>/lib/ruby/<version>/extensions/<archetecture>-<platform>/<version>/<gemname>-<gemversion>` or
+    any other ruby dependency
     The gem_path is `<bundle_name>/lib/ruby/<version>` so we can go from an incpath to the
     gem_path pretty easily without much additional work.
     """
     if len(incpaths) == 0:
         return ""
-    incpath = incpaths[0]
-    return incpath.rsplit("/", 3)[0]
-
+    for incpath in incpaths:
+        print(incpath)
+        parts = incpath.split('/', 4)
+        if len(parts) == 5 and parts[1] == 'lib' and parts[2] == 'ruby':
+            return '/'.join(parts[:4])
+    return ""
 # Having this function allows us to override otherwise frozen attributes
 # such as main, srcs and deps. We use this in ruby_rspec_test rule by
 # adding rspec as a main, and sources, and rspec gem as a dependency.

--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -274,9 +274,9 @@ class BundleBuildFileGenerator
 
     gem_lib_paths = require_paths.map do |require_path|
       require_pathname = Pathname.new(require_path)
-      # Require_paths can include absolute paths to gem extensions.
+      # Require_path may be an absolute path to a gem extension.
       if require_pathname.absolute?
-        # require_pathname is absolute. Compute the relative path from gem_path.
+        # Computing the relative path to gem_path to match the other files in require_paths
         require_pathname = require_pathname.relative_path_from(File.absolute_path(gem_path))
       end
       Pathname.new(gem_path).join(require_pathname).cleanpath.to_s

--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -272,15 +272,14 @@ class BundleBuildFileGenerator
     # some gems also require additional paths to be included in the load paths.
     require_paths += include_array(spec.name)
 
-    # Require_paths can include absolute paths to gem extensions.
-    gem_pathname = Pathname.new(gem_path)
     gem_lib_paths = require_paths.map do |require_path|
       require_pathname = Pathname.new(require_path)
+      # Require_paths can include absolute paths to gem extensions.
       if require_pathname.absolute?
         # require_pathname is absolute. Compute the relative path from gem_path.
         require_pathname = require_pathname.relative_path_from(File.absolute_path(gem_path))
       end
-      gem_pathname.join(require_pathname).cleanpath.to_s
+      Pathname.new(gem_path).join(require_pathname).cleanpath.to_s
     end
     bundle_lib_paths.push(*gem_lib_paths)
 

--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -271,7 +271,17 @@ class BundleBuildFileGenerator
     # Usually, registering the directory paths listed in the `require_paths` of gemspecs is sufficient, but
     # some gems also require additional paths to be included in the load paths.
     require_paths += include_array(spec.name)
-    gem_lib_paths = require_paths.map { |require_path| File.join(gem_path, require_path) }
+
+    # Require_paths can include absolute paths to gem extensions.
+    gem_pathname = Pathname.new(gem_path)
+    gem_lib_paths = require_paths.map do |require_path|
+      require_pathname = Pathname.new(require_path)
+      if require_pathname.absolute?
+        # require_pathname is absolute. Compute the relative path from gem_path.
+        require_pathname = require_pathname.relative_path_from(File.absolute_path(gem_path))
+      end
+      gem_pathname.join(require_pathname).cleanpath.to_s
+    end
     bundle_lib_paths.push(*gem_lib_paths)
 
     # paths to search for executables


### PR DESCRIPTION
Require_paths is not always a relative_path. 
When it is a path to a gem extension it is given to us as an absolute path like:
`/<bazel_cache_dir>/external/bundle/lib/ruby/2.7.0/extensions/x86_64-linux/2.7.0/pg-1.0.0`
Previously this would be appended to gem_path and look like 
`lib/ruby/2.7.0/gems/pg-1.0.0/<bazel_cache_dir>/external/bundle/lib/ruby/2.7.0/extensions/x86_64-linux/2.7.0/pg-1.0.0` which does not resolve to a real file.
This new code converts that absolute path to a relative path from the expected directory and the output looks like:
`lib/ruby/2.7.0/extensions/x86_64-linux/2.7.0/pg-1.0.0`